### PR TITLE
build: add tailwind-indicator

### DIFF
--- a/src/components/tailwind-indicator.svelte
+++ b/src/components/tailwind-indicator.svelte
@@ -1,0 +1,20 @@
+<script>
+	let showIndicator = false;
+
+	if (process.env.NODE_ENV === 'development') {
+		showIndicator = true;
+	}
+</script>
+
+{#if showIndicator}
+	<div
+		class="fixed bottom-1 left-1 z-50 flex h-6 w-6 items-center justify-center rounded-full bg-black p-3 text-xs text-white"
+	>
+		<div class="block sm:hidden">xs</div>
+		<div class="hidden sm:block md:hidden">sm</div>
+		<div class="hidden md:block lg:hidden">md</div>
+		<div class="hidden lg:block xl:hidden">lg</div>
+		<div class="hidden xl:block 2xl:hidden">xl</div>
+		<div class="hidden 2xl:block">2xl</div>
+	</div>
+{/if}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,11 +4,16 @@
 	import '../styles/index.css';
 
 	import { InlineNotification } from 'carbon-components-svelte';
+
+	import TailwindIndicator from '$components/tailwind-indicator.svelte';
 </script>
 
 <slot />
+
+<TailwindIndicator />
+
 <InlineNotification
-	class="fixed z-50 w-full left-0 bottom-0 m-0 max-w-none min-w-0"
+	class="fixed z-40 w-full left-0 bottom-0 m-0 max-w-none min-w-0"
 	lowContrast
 	kind="warning-alt"
 	title="คำเตือน:"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,7 +8,11 @@ export default {
 	},
 	theme: {
 		screens: {
-			md: '672px'
+			sm: '576px', // Small screens
+			md: '672px', // Medium screens
+			lg: '992px', // Large screens
+			xl: '1200px', // Extra-large screens
+			'2xl': '1400px' // Extra-extra-large screens
 		},
 		fontFamily: {
 			serif: ['Kondolar Thai', ...defaultTheme.fontFamily.serif],


### PR DESCRIPTION
Inspired from [shadcn-ui/next-template](https://github.com/shadcn-ui/next-template)

indicator show media query size for tailwind.
been use one time and every addicted to it, this one show on your left bottom screen it show size of current media query only when development which can be call from process.env.NODE_ENV.

it's not a components just helper function so maybe no need for histoire?

and also add more more theme/screens in tailwind.config.js but still keep base only one 
md: '672px'

any suggestion would be cooool kub.
with ❤️ 