### PR TITLE
Initial NavigationBar , SideMenu, Sidenav, adding more breakpoint

### DIFF
--- a/src/components/NavigationBar/NavigationBar.story.svelte
+++ b/src/components/NavigationBar/NavigationBar.story.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	import type { Hst } from '@histoire/plugin-svelte';
+	import NavigationBar from './NavigationBar.svelte';
+	export let Hst: Hst;
+</script>
+
+<Hst.Story title="NavigationBar">
+	<NavigationBar />
+</Hst.Story>

--- a/src/components/NavigationBar/NavigationBar.svelte
+++ b/src/components/NavigationBar/NavigationBar.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import Menu from 'carbon-icons-svelte/lib/Menu.svelte';
+	import Close from 'carbon-icons-svelte/lib/Close.svelte';
+
+	let sideNavActive = false;
+	$: console.log(sideNavActive);
+</script>
+
+<header class="flex sticky items-center justify-between h-12 px-8 bg-[#161616]">
+	<div class="leading flex">
+		<button
+			class="flex items-center justify-center bg-[#161616] border-0 mr-4 cursor-pointer lg:hidden"
+			on:click={() => (sideNavActive = !sideNavActive)}
+		>
+			{#if !sideNavActive}
+				<Menu fill="white" size={24} aria-label="Open Menu" />
+			{:else}
+				<Close fill="white" size={24} aria-label="Close Menu" />
+			{/if}
+		</button>
+
+		<a href="/">
+			<picture class="flex items-center h-full">
+				<source media="(min-width: 1056px)" srcset="/images/logo/pw-long-white.png" height="18" />
+				<img src="/images/logo/pw-short-white.png" alt="Parliament Watch" height="28" />
+			</picture>
+		</a>
+	</div>
+	<div class="nav" />
+	<div class="trailing" />
+</header>

--- a/src/components/NavigationBar/NavigationBar.svelte
+++ b/src/components/NavigationBar/NavigationBar.svelte
@@ -1,24 +1,52 @@
 <script lang="ts">
-	import Menu from 'carbon-icons-svelte/lib/Menu.svelte';
-	import Close from 'carbon-icons-svelte/lib/Close.svelte';
+	import { TestTool } from 'carbon-icons-svelte';
+	import SideMenu from './SideMenu.svelte';
+	import SideNav from './SideNav.svelte';
+	import PoliticianIcon from '$components/icons/PoliticianIcon.svelte';
+	import LawIcon from '$components/icons/LawIcon.svelte';
+	import VoteIcon from '$components/icons/VoteIcon.svelte';
 
 	let sideNavActive = false;
-	$: console.log(sideNavActive);
+	let screenSize: number;
+	$: if (screenSize > 1056) sideNavActive = false;
+
+	let menuList = [
+		{
+			label: 'สมาชิกรัฐสภา',
+			icon: PoliticianIcon,
+			sub: [
+				{ label: 'สภาผู้แทนราษฎร', icon: '' },
+				{ label: 'วุฒิสภา', icon: '' }
+			]
+		},
+		{
+			label: 'การออกกฎหมาย',
+			icon: LawIcon,
+			sub: [
+				{ label: 'กฎหมายในกระบวนการ', icon: '' },
+				{ label: 'รัฐออกกฎหมายอย่างไร', icon: '' }
+			]
+		},
+		{
+			label: 'การลงมติ',
+			icon: VoteIcon
+		},
+		{
+			label: 'เกี่ยวกับเรา',
+			icon: '',
+			sub: [
+				{ label: 'ที่มาของโครงการ', icon: '' },
+				{ label: 'ข้อมูลในเว็บนี้', icon: '' },
+				{ label: 'เกี่ยวกับ WeVis', icon: '' }
+			]
+		}
+	];
 </script>
 
-<header class="flex sticky items-center justify-between h-12 px-8 bg-[#161616]">
+<svelte:window bind:innerWidth={screenSize} />
+<header class="flex sticky items-center justify-between h-12 px-6 lg:px-10 bg-gray-100 z-20">
 	<div class="leading flex">
-		<button
-			class="flex items-center justify-center bg-[#161616] border-0 mr-4 cursor-pointer lg:hidden"
-			on:click={() => (sideNavActive = !sideNavActive)}
-		>
-			{#if !sideNavActive}
-				<Menu fill="white" size={24} aria-label="Open Menu" />
-			{:else}
-				<Close fill="white" size={24} aria-label="Close Menu" />
-			{/if}
-		</button>
-
+		<SideMenu isActive={sideNavActive} on:click={() => (sideNavActive = !sideNavActive)} />
 		<a href="/">
 			<picture class="flex items-center h-full">
 				<source media="(min-width: 1056px)" srcset="/images/logo/pw-long-white.png" height="18" />
@@ -29,3 +57,28 @@
 	<div class="nav" />
 	<div class="trailing" />
 </header>
+<SideNav isActive={sideNavActive}>
+	<ul>
+		{#each menuList as menu}
+			<div class="flex flex-col">
+				<li class="font-gray-10 p-2">{menu.label}</li>
+				{#if menu.sub}
+					<div class="pl-8">
+						<ul>
+							{#each menu.sub as sub, idx}
+								{#if idx < menu.sub.length - 1}
+									<hr class="  border-0 border-b p-0 m-0 border-gray-30/20 z-40" />
+								{/if}
+								<li class=" font-extralight font-gray-30 p-2">{sub.label}</li>
+								{#if idx < menu.sub.length - 1}
+									<hr class=" border-0 border-b p-0 m-0 border-gray-30/20 z-40" />
+								{/if}
+							{/each}
+						</ul>
+					</div>
+				{/if}
+			</div>
+			<hr class=" border-0 border-b p-0 m-0 border-gray-30/20 z-40" />
+		{/each}
+	</ul>
+</SideNav>

--- a/src/components/NavigationBar/SideMenu.svelte
+++ b/src/components/NavigationBar/SideMenu.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import MenuIcon from 'carbon-icons-svelte/lib/Menu.svelte';
+	import CloseIcon from 'carbon-icons-svelte/lib/Close.svelte';
+
+	export let isActive = false;
+</script>
+
+<button
+	class="flex items-center justify-left bg-gray-100 border-0 p-0 mr-4 cursor-pointer lg:hidden"
+	on:click
+>
+	{#if !isActive}
+		<MenuIcon fill="white" size={24} aria-label="Open Menu" />
+	{:else}
+		<CloseIcon fill="white" size={24} aria-label="Close Menu" />
+	{/if}
+</button>

--- a/src/components/NavigationBar/SideNav.svelte
+++ b/src/components/NavigationBar/SideNav.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	export let isActive = false;
+</script>
+
+<aside
+	class="absolute top-0 left-0 h-screen pt-12 text-white bg-gray-80 z-10 w-80 opacity-100 transition-all duration-200 overflow-hidden"
+	class:!w-0={!isActive}
+	class:opacity-0={!isActive}
+>
+	<div class="pt-4">
+		<slot />
+	</div>
+</aside>
+
+<div
+	class="absolute top-0 left-0 h-screen backdrop-brightness-125 bg-white/50 w-full z-0"
+	class:hidden={!isActive}
+/>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,10 +2,11 @@
 	import '../styles/carbon/pre-compiled.css';
 	import '../styles/carbon/colors.scss';
 	import '../styles/index.css';
-
+	import NavigationBar from '$components/NavigationBar/NavigationBar.svelte';
 	import { InlineNotification } from 'carbon-components-svelte';
 </script>
 
+<NavigationBar />
 <slot />
 <InlineNotification
 	class="fixed z-50 w-full left-0 bottom-0 m-0 max-w-none min-w-0"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,7 +8,11 @@ export default {
 	},
 	theme: {
 		screens: {
-			md: '672px'
+			///modified break point base on : https://carbon-components-svelte.onrender.com/components/Breakpoint
+			sm: '320px',
+			md: '672px',
+			lg: '1056px',
+			xl: '1312px'
 		},
 		fontFamily: {
 			serif: ['Kondolar Thai', ...defaultTheme.fontFamily.serif],


### PR DESCRIPTION
Initialize code for Navigation bar (NavigationBar.svlete)
Initialize code for side menu button  (SideMenu.svelte)
Initialize code for side navigation pane (SideNav.svelte)

adding  more breakpoint variable on `tailwind.config` 

```
screens: {
	///modified break point base on : https://carbon-components-svelte.onrender.com/components/Breakpoint
	sm: '320px',
	md: '672px',
	lg: '1056px',
	xl: '1312px'
},
```

