### PR TITLE
Icyscools/#20 Add Legislative Process Page: Body Skeleton

### DIFF
--- a/src/routes/legislative-process/+page.svelte
+++ b/src/routes/legislative-process/+page.svelte
@@ -9,7 +9,7 @@
 
 <div class="flex flex-col w-full">
 	<header class="bg-teal-20">
-		<div class="w-full max-w-[800px] px-10 py-10 md:py-20">
+		<div class="w-full max-w-[800px] px-10 py-10 md:py-20 mx-auto">
 			<h1 class="fluid-heading-05 mb-4">ร่างกฎหมายกลายเป็นกฎหมายได้อย่างไร</h1>
 			<p>
 				<span class="text-text-primary font-bold">อัปเดตล่าสุด :</span>
@@ -17,7 +17,9 @@
 			</p>
 		</div>
 	</header>
-	<div class="w-full max-w-[800px] flex flex-col gap-10 px-4 md:px-10 py-8 bg-ui-01 md:bg-white">
+	<div
+		class="w-full max-w-[800px] flex flex-col gap-10 px-4 md:px-10 py-8 bg-ui-01 md:bg-white mx-auto"
+	>
 		<section class="flex flex-col gap-4 bg-white px-4 md:px-0 py-8 md:py-0">
 			<h1 class="fluid-heading-05 text-text-primary mb-4">แนะนำภาพรวม</h1>
 			<div>

--- a/src/routes/legislative-process/+page.svelte
+++ b/src/routes/legislative-process/+page.svelte
@@ -10,7 +10,7 @@
 <div class="flex flex-col w-full">
 	<header class="bg-teal-20">
 		<div class="w-full max-w-[800px] px-10 py-10 md:py-20 mx-auto">
-			<h1 class="fluid-heading-05 mb-4">ร่างกฎหมายกลายเป็นกฎหมายได้อย่างไร</h1>
+			<h1 class="fluid-heading-05">ร่างกฎหมายกลายเป็นกฎหมายได้อย่างไร</h1>
 			<p>
 				<span class="text-text-primary font-bold">อัปเดตล่าสุด :</span>
 				<span class="text-helper-text-01">{dayjs(new Date()).format('DD MMM BBBB')}</span>
@@ -20,69 +20,87 @@
 	<div
 		class="w-full max-w-[800px] flex flex-col gap-10 px-4 md:px-10 py-8 bg-ui-01 md:bg-white mx-auto"
 	>
-		<section class="flex flex-col gap-4 bg-white px-4 md:px-0 py-8 md:py-0">
-			<h1 class="fluid-heading-05 text-text-primary mb-4">แนะนำภาพรวม</h1>
+		<section>
+			<h1 class="fluid-heading-05">แนะนำภาพรวม</h1>
 			<div>
-				<h2 class="fluid-heading-04 text-text-primary mb-4">กฎหมายสำเร็จได้อย่างไร</h2>
-				<hr class="border-0 border-solid border-gray-20 border-t w-full box-border" />
+				<h2 class="fluid-heading-04">กฎหมายสำเร็จได้อย่างไร</h2>
+				<hr />
 			</div>
 			<div>
-				<h2 class="fluid-heading-04 text-text-primary mb-4">กฎหมายในเว็บไซต์นี้</h2>
-				<hr class="border-0 border-solid border-gray-20 border-t w-full box-border" />
+				<h2 class="fluid-heading-04">กฎหมายในเว็บไซต์นี้</h2>
+				<hr />
 			</div>
 			<div>
-				<h2 class="fluid-heading-04 text-text-primary mb-4">ประเภทของกฎหมาย</h2>
-				<hr class="border-0 border-solid border-gray-20 border-t w-full box-border" />
+				<h2 class="fluid-heading-04">ประเภทของกฎหมาย</h2>
+				<hr />
 			</div>
 			<div>
-				<h2 class="fluid-heading-04 text-text-primary mb-4">สถานะของกฎหมาย</h2>
-				<hr class="border-0 border-solid border-gray-20 border-t w-full box-border" />
-			</div>
-		</section>
-		<section class="flex flex-col gap-4 bg-white px-4 md:px-0 py-8 md:py-0">
-			<h1 class="fluid-heading-05 text-text-primary mb-4">ขั้นตอนของกฎหมาย</h1>
-			<div>
-				<h2 class="fluid-heading-04 text-text-primary mb-4">ที่มาของกฎหมาย</h2>
-				<hr class="border-0 border-solid border-gray-20 border-t w-full box-border" />
-			</div>
-			<div>
-				<h2 class="fluid-heading-04 text-text-primary mb-4">ขั้นตอนโดยย่อ</h2>
-				<hr class="border-0 border-solid border-gray-20 border-t w-full box-border" />
-			</div>
-			<div>
-				<h2 class="fluid-heading-04 text-text-primary mb-4">ขั้นตอนโดยละเอียด</h2>
-				<hr class="border-0 border-solid border-gray-20 border-t w-full box-border" />
+				<h2 class="fluid-heading-04">สถานะของกฎหมาย</h2>
+				<hr />
 			</div>
 		</section>
-		<section class="flex flex-col gap-4 bg-white px-4 md:px-0 py-8 md:py-0">
-			<h1 class="fluid-heading-05 text-text-primary mb-4">ประเภทของการลงมติ</h1>
+		<section>
+			<h1 class="fluid-heading-05">ขั้นตอนของกฎหมาย</h1>
 			<div>
-				<h2 class="fluid-heading-04 text-text-primary mb-4">ประเภทของการลงมติ</h2>
-				<hr class="border-0 border-solid border-gray-20 border-t w-full box-border" />
+				<h2 class="fluid-heading-04">ที่มาของกฎหมาย</h2>
+				<hr />
 			</div>
 			<div>
-				<h2 class="fluid-heading-04 text-text-primary mb-4">ผลของการลงมติ</h2>
-				<hr class="border-0 border-solid border-gray-20 border-t w-full box-border" />
+				<h2 class="fluid-heading-04">ขั้นตอนโดยย่อ</h2>
+				<hr />
 			</div>
 			<div>
-				<h2 class="fluid-heading-04 text-text-primary mb-4">การลงมติอื่นๆ</h2>
-				<hr class="border-0 border-solid border-gray-20 border-t w-full box-border" />
+				<h2 class="fluid-heading-04">ขั้นตอนโดยละเอียด</h2>
+				<hr />
 			</div>
 		</section>
-		<section class="flex flex-col gap-4 bg-white px-4 md:px-0 py-8 md:py-0">
-			<h1 class="fluid-heading-05 text-text-primary mb-4">ส.ส. และ ส.ว. ทำอะไรบ้างในสภา</h1>
+		<section>
+			<h1 class="fluid-heading-05">ประเภทของการลงมติ</h1>
 			<div>
-				<h2 class="fluid-heading-04 text-text-primary mb-4">หน้าที่ของ ส.ส.</h2>
-				<hr class="border-0 border-solid border-gray-20 border-t w-full box-border" />
+				<h2 class="fluid-heading-04">ประเภทของการลงมติ</h2>
+				<hr />
 			</div>
 			<div>
-				<h2 class="fluid-heading-04 text-text-primary mb-4">หน้าที่ของ ส.ว.</h2>
-				<hr class="border-0 border-solid border-gray-20 border-t w-full box-border" />
+				<h2 class="fluid-heading-04">ผลของการลงมติ</h2>
+				<hr />
 			</div>
 			<div>
-				<h2 class="fluid-heading-04 text-text-primary mb-4">หน้าที่ของสภาร่วม (ส.ส. + ส.ว.)</h2>
-				<hr class="border-0 border-solid border-gray-20 border-t w-full box-border" />
+				<h2 class="fluid-heading-04">การลงมติอื่นๆ</h2>
+				<hr />
+			</div>
+		</section>
+		<section>
+			<h1 class="fluid-heading-05">ส.ส. และ ส.ว. ทำอะไรบ้างในสภา</h1>
+			<div>
+				<h2 class="fluid-heading-04">หน้าที่ของ ส.ส.</h2>
+				<hr />
+			</div>
+			<div>
+				<h2 class="fluid-heading-04">หน้าที่ของ ส.ว.</h2>
+				<hr />
+			</div>
+			<div>
+				<h2 class="fluid-heading-04">หน้าที่ของสภาร่วม (ส.ส. + ส.ว.)</h2>
+				<hr />
 			</div>
 		</section>
 	</div>
 </div>
+
+<style lang="postcss">
+	section {
+		@apply flex flex-col gap-4 bg-white px-4 md:px-0 py-8 md:py-0;
+	}
+
+	h1 {
+		@apply text-text-primary mb-4;
+	}
+
+	h2 {
+		@apply text-text-primary mb-4;
+	}
+
+	hr {
+		@apply border-0 border-solid border-gray-20 border-t w-full box-border;
+	}
+</style>

--- a/src/routes/legislative-process/+page.svelte
+++ b/src/routes/legislative-process/+page.svelte
@@ -1,1 +1,86 @@
-<h1>ร่างกฎหมายกลายเป็นกฎหมายได้อย่างไร</h1>
+<script land="ts">
+	import dayjs from 'dayjs';
+	import buddhistEra from 'dayjs/plugin/buddhistEra';
+	import 'dayjs/locale/th';
+
+	dayjs.extend(buddhistEra);
+	dayjs.locale('th');
+</script>
+
+<div class="flex flex-col w-full">
+	<header class="bg-teal-20">
+		<div class="w-full max-w-[800px] px-10 py-10 md:py-20">
+			<h1 class="fluid-heading-05 mb-4">ร่างกฎหมายกลายเป็นกฎหมายได้อย่างไร</h1>
+			<p>
+				<span class="text-text-primary font-bold">อัปเดตล่าสุด :</span>
+				<span class="text-helper-text-01">{dayjs(new Date()).format('DD MMM BBBB')}</span>
+			</p>
+		</div>
+	</header>
+	<div class="w-full max-w-[800px] flex flex-col gap-10 px-4 md:px-10 py-8 bg-ui-01 md:bg-white">
+		<section class="flex flex-col gap-4 bg-white px-4 md:px-0 py-8 md:py-0">
+			<h1 class="fluid-heading-05 text-text-primary mb-4">แนะนำภาพรวม</h1>
+			<div>
+				<h2 class="fluid-heading-04 text-text-primary mb-4">กฎหมายสำเร็จได้อย่างไร</h2>
+				<hr class="border-0 border-solid border-gray-20 border-t w-full box-border" />
+			</div>
+			<div>
+				<h2 class="fluid-heading-04 text-text-primary mb-4">กฎหมายในเว็บไซต์นี้</h2>
+				<hr class="border-0 border-solid border-gray-20 border-t w-full box-border" />
+			</div>
+			<div>
+				<h2 class="fluid-heading-04 text-text-primary mb-4">ประเภทของกฎหมาย</h2>
+				<hr class="border-0 border-solid border-gray-20 border-t w-full box-border" />
+			</div>
+			<div>
+				<h2 class="fluid-heading-04 text-text-primary mb-4">สถานะของกฎหมาย</h2>
+				<hr class="border-0 border-solid border-gray-20 border-t w-full box-border" />
+			</div>
+		</section>
+		<section class="flex flex-col gap-4 bg-white px-4 md:px-0 py-8 md:py-0">
+			<h1 class="fluid-heading-05 text-text-primary mb-4">ขั้นตอนของกฎหมาย</h1>
+			<div>
+				<h2 class="fluid-heading-04 text-text-primary mb-4">ที่มาของกฎหมาย</h2>
+				<hr class="border-0 border-solid border-gray-20 border-t w-full box-border" />
+			</div>
+			<div>
+				<h2 class="fluid-heading-04 text-text-primary mb-4">ขั้นตอนโดยย่อ</h2>
+				<hr class="border-0 border-solid border-gray-20 border-t w-full box-border" />
+			</div>
+			<div>
+				<h2 class="fluid-heading-04 text-text-primary mb-4">ขั้นตอนโดยละเอียด</h2>
+				<hr class="border-0 border-solid border-gray-20 border-t w-full box-border" />
+			</div>
+		</section>
+		<section class="flex flex-col gap-4 bg-white px-4 md:px-0 py-8 md:py-0">
+			<h1 class="fluid-heading-05 text-text-primary mb-4">ประเภทของการลงมติ</h1>
+			<div>
+				<h2 class="fluid-heading-04 text-text-primary mb-4">ประเภทของการลงมติ</h2>
+				<hr class="border-0 border-solid border-gray-20 border-t w-full box-border" />
+			</div>
+			<div>
+				<h2 class="fluid-heading-04 text-text-primary mb-4">ผลของการลงมติ</h2>
+				<hr class="border-0 border-solid border-gray-20 border-t w-full box-border" />
+			</div>
+			<div>
+				<h2 class="fluid-heading-04 text-text-primary mb-4">การลงมติอื่นๆ</h2>
+				<hr class="border-0 border-solid border-gray-20 border-t w-full box-border" />
+			</div>
+		</section>
+		<section class="flex flex-col gap-4 bg-white px-4 md:px-0 py-8 md:py-0">
+			<h1 class="fluid-heading-05 text-text-primary mb-4">ส.ส. และ ส.ว. ทำอะไรบ้างในสภา</h1>
+			<div>
+				<h2 class="fluid-heading-04 text-text-primary mb-4">หน้าที่ของ ส.ส.</h2>
+				<hr class="border-0 border-solid border-gray-20 border-t w-full box-border" />
+			</div>
+			<div>
+				<h2 class="fluid-heading-04 text-text-primary mb-4">หน้าที่ของ ส.ว.</h2>
+				<hr class="border-0 border-solid border-gray-20 border-t w-full box-border" />
+			</div>
+			<div>
+				<h2 class="fluid-heading-04 text-text-primary mb-4">หน้าที่ของสภาร่วม (ส.ส. + ส.ว.)</h2>
+				<hr class="border-0 border-solid border-gray-20 border-t w-full box-border" />
+			</div>
+		</section>
+	</div>
+</div>


### PR DESCRIPTION
Related to #20.

This PR intended to add legislative process heading text and their styles according to this [Figma design](https://www.figma.com/file/cdtZnPegHm5CGHWqIND5Im/Design_Phase01?type=design&node-id=319-155076&mode=dev).

- [x] Add a Blue Title section. Use the current timestamp for the updated date for now.
- [x] Add every heading 1 and heading 2 texts.
- [x] The body should be responsive.

Note that: I set `max-width` equals to 800px as same as this design's body width on desktop size, but not sure if we have any specific breakpoint.


Example
---

Viewport of 320px width.

![image](https://github.com/wevisdemo/parliament-watch/assets/30778789/cbe695e1-5ffd-4c4a-a9f3-f49c70bbd088)

---

Viewport of 800px width.

![image](https://github.com/wevisdemo/parliament-watch/assets/30778789/3322b0c6-dab3-4b69-8520-7dabe2d4741f)

---

Viewport of 1024px width.

![image](https://github.com/wevisdemo/parliament-watch/assets/30778789/359a0495-ad61-4fb6-9fb8-81f1609a9a43)
