### PR TITLE
Badgooooor/#29 Proposer component

### DIFF
--- a/src/components/Proposer/Proposer.story.svelte
+++ b/src/components/Proposer/Proposer.story.svelte
@@ -8,19 +8,25 @@
 	export let Hst: Hst;
 </script>
 
-<Hst.Story title="Proposer">
-	<Proposer
-		partyPolitician={{
-			politician: movingForwardPolitician,
-			assembly: rep26,
-			party: movingForwardParty
-		}}
-	/>
-	<Proposer assembly={rep26} />
-	<Proposer
-		common={{
-			name: 'นายยิ่งชีพ อัชชานนท์',
-			description: 'และประชาชน 200,000 คน'
-		}}
-	/>
+<Hst.Story title="Proposer" layout={{ type: 'grid', width: 400 }}>
+	<Hst.Variant title="Politician">
+		<Proposer
+			partyPolitician={{
+				politician: movingForwardPolitician,
+				assembly: rep26,
+				party: movingForwardParty
+			}}
+		/>
+	</Hst.Variant>
+	<Hst.Variant title="Assembly">
+		<Proposer assembly={rep26} />
+	</Hst.Variant>
+	<Hst.Variant title="Others">
+		<Proposer
+			common={{
+				name: 'นายยิ่งชีพ อัชชานนท์',
+				description: 'และประชาชน 200,000 คน'
+			}}
+		/>
+	</Hst.Variant>
 </Hst.Story>

--- a/src/components/Proposer/Proposer.story.svelte
+++ b/src/components/Proposer/Proposer.story.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	import type { Hst } from '@histoire/plugin-svelte';
+	import Proposer from './Proposer.svelte';
+	export let Hst: Hst;
+</script>
+
+<Hst.Story title="Proposer">
+	<Proposer />
+</Hst.Story>

--- a/src/components/Proposer/Proposer.story.svelte
+++ b/src/components/Proposer/Proposer.story.svelte
@@ -1,9 +1,17 @@
 <script lang="ts">
 	import type { Hst } from '@histoire/plugin-svelte';
 	import Proposer from './Proposer.svelte';
+	import { rep26 } from '../../mocks/data/assembly';
+
 	export let Hst: Hst;
 </script>
 
 <Hst.Story title="Proposer">
-	<Proposer />
+	<Proposer assembly={rep26} />
+	<Proposer
+		common={{
+			name: 'นายยิ่งชีพ อัชชานนท',
+			description: 'และประชาชน 200,000 คน'
+		}}
+	/>
 </Hst.Story>

--- a/src/components/Proposer/Proposer.story.svelte
+++ b/src/components/Proposer/Proposer.story.svelte
@@ -19,7 +19,7 @@
 	<Proposer assembly={rep26} />
 	<Proposer
 		common={{
-			name: 'นายยิ่งชีพ อัชชานนท',
+			name: 'นายยิ่งชีพ อัชชานนท์',
 			description: 'และประชาชน 200,000 คน'
 		}}
 	/>

--- a/src/components/Proposer/Proposer.story.svelte
+++ b/src/components/Proposer/Proposer.story.svelte
@@ -12,6 +12,7 @@
 	<Proposer
 		partyPolitician={{
 			politician: movingForwardPolitician,
+			assembly: rep26,
 			party: movingForwardParty
 		}}
 	/>

--- a/src/components/Proposer/Proposer.story.svelte
+++ b/src/components/Proposer/Proposer.story.svelte
@@ -2,11 +2,19 @@
 	import type { Hst } from '@histoire/plugin-svelte';
 	import Proposer from './Proposer.svelte';
 	import { rep26 } from '../../mocks/data/assembly';
+	import { movingForwardPolitician } from '../../mocks/data/politician';
+	import { movingForwardParty } from '../../mocks/data/party';
 
 	export let Hst: Hst;
 </script>
 
 <Hst.Story title="Proposer">
+	<Proposer
+		partyPolitician={{
+			politician: movingForwardPolitician,
+			party: movingForwardParty
+		}}
+	/>
 	<Proposer assembly={rep26} />
 	<Proposer
 		common={{

--- a/src/components/Proposer/Proposer.svelte
+++ b/src/components/Proposer/Proposer.svelte
@@ -26,7 +26,7 @@
 	export let assembly: Assembly | undefined = undefined;
 	export let common: CommonProposer | undefined = undefined;
 
-	$: proposerName = () => {
+	$: proposerName = (() => {
 		if (partyPolitician) {
 			const { politician } = partyPolitician;
 			return [politician.prefix ?? '', politician.firstname, politician.lastname].join(' ');
@@ -37,12 +37,12 @@
 		}
 
 		return '';
-	};
+	})();
 
 	const getAssemblyTermText = (assembly: Assembly) =>
 		`ชุดที่ ${assembly.term} (${dayjs(assembly.startedAt).format('BBBB')})`;
 
-	$: proposerTerm = () => {
+	$: proposerTerm = (() => {
 		if (partyPolitician?.assembly) {
 			return `${partyPolitician.assembly.abbreviation} ${getAssemblyTermText(
 				partyPolitician.assembly
@@ -52,7 +52,7 @@
 		}
 
 		return '';
-	};
+	})();
 </script>
 
 <div class="flex flex-col sm:flex-row justify-start items-start">
@@ -62,7 +62,7 @@
 				class="w-full h-full rounded-full object-cover"
 				loading="lazy"
 				decoding="async"
-				alt={`${partyPolitician.politician.firstname} ${partyPolitician.politician.lastname}`}
+				alt="{partyPolitician.politician.firstname} {partyPolitician.politician.lastname}"
 				src={partyPolitician.politician.avatar}
 			/>
 		{:else if assembly}
@@ -76,7 +76,7 @@
 		{/if}
 	</div>
 	<p class="body-01 sm:ml-1 break-words">
-		<span class="text-text-01">{proposerName()} {proposerTerm()}</span>
+		<span class="text-text-01">{proposerName} {proposerTerm}</span>
 		<br class="sm:hidden" />
 		{#if common?.description}
 			<span class="text-text-02">{common.description}</span>

--- a/src/components/Proposer/Proposer.svelte
+++ b/src/components/Proposer/Proposer.svelte
@@ -1,17 +1,59 @@
 <script lang="ts">
+	import PeopleIcon from '$components/icons/PeopleIcon.svelte';
+	import PoliticianIcon from '$components/icons/PoliticianIcon.svelte';
+	import type { Assembly } from '$models/assembly';
+	import dayjs from 'dayjs';
+
+	type CommonProposer = {
+		name: string;
+		description?: string;
+	};
+
+	export let assembly: Assembly | undefined = undefined;
+	export let common: CommonProposer | undefined = undefined;
+
+	$: proposerName = () => {
+		if (assembly) {
+			return assembly.name;
+		} else if (common) {
+			return common.name;
+		}
+
+		return '';
+	};
+
+	$: proposerTerm = () => {
+		if (assembly) {
+			return `ชุดที่ ${assembly.term} (${dayjs(assembly.startedAt).year()})`;
+		}
+
+		return '';
+	};
 </script>
 
-<div class="flex flex-col sm:flex-row sm:items-center">
+<div class="flex flex-col sm:flex-row items-start sm:items-center">
 	<div class="w-6 h-6">
-		<img
+		<!-- <img
 			class="w-full h-full rounded-full object-cover"
 			loading="lazy"
 			decoding="async"
 			alt="proposer avatar"
-		/>
+		/> -->
+		{#if assembly}
+			<div class="flex items-center justify-center w-full h-full rounded-full bg-black">
+				<PoliticianIcon class="text-white" />
+			</div>
+		{/if}
+		{#if common}
+			<div class="flex items-center justify-center w-full h-full rounded-full bg-black">
+				<PeopleIcon class="text-white" />
+			</div>
+		{/if}
 	</div>
 	<div class="mt-1 sm:ml-1 break-words">
-		<span>very long name</span>
-		<span>description </span>
+		<span class="text-text-01">{proposerName()} {proposerTerm()}</span>
+		{#if common?.description}
+			<span class="text-text-02">{common.description}</span>
+		{/if}
 	</div>
 </div>

--- a/src/components/Proposer/Proposer.svelte
+++ b/src/components/Proposer/Proposer.svelte
@@ -13,6 +13,7 @@
 
 	type PartyPolitician = {
 		politician: Politician;
+		assembly: Assembly;
 		party: Party;
 	};
 
@@ -33,9 +34,16 @@
 		return '';
 	};
 
+	const getAssemblyTermText = (assembly: Assembly) =>
+		`ชุดที่ ${assembly.term} (${dayjs(assembly.startedAt).year()})`;
+
 	$: proposerTerm = () => {
-		if (assembly) {
-			return `ชุดที่ ${assembly.term} (${dayjs(assembly.startedAt).year()})`;
+		if (partyPolitician?.assembly) {
+			return `${partyPolitician.assembly.abbreviation} ${getAssemblyTermText(
+				partyPolitician.assembly
+			)}`;
+		} else if (assembly) {
+			return getAssemblyTermText(assembly);
 		}
 
 		return '';

--- a/src/components/Proposer/Proposer.svelte
+++ b/src/components/Proposer/Proposer.svelte
@@ -5,6 +5,11 @@
 	import type { Party } from '$models/party';
 	import type { Politician } from '$models/politician';
 	import dayjs from 'dayjs';
+	import 'dayjs/locale/th';
+	import buddhistEra from 'dayjs/plugin/buddhistEra';
+
+	dayjs.extend(buddhistEra);
+	dayjs.locale('th');
 
 	type CommonProposer = {
 		name: string;
@@ -35,7 +40,7 @@
 	};
 
 	const getAssemblyTermText = (assembly: Assembly) =>
-		`ชุดที่ ${assembly.term} (${dayjs(assembly.startedAt).year()})`;
+		`ชุดที่ ${assembly.term} (${dayjs(assembly.startedAt).format('BBBB')})`;
 
 	$: proposerTerm = () => {
 		if (partyPolitician?.assembly) {
@@ -70,7 +75,7 @@
 			</div>
 		{/if}
 	</div>
-	<div class="sm:ml-1 break-words">
+	<p class="body-01 sm:ml-1 break-words">
 		<span class="text-text-01">{proposerName()} {proposerTerm()}</span>
 		{#if common?.description}
 			<span class="text-text-02">{common.description}</span>
@@ -78,5 +83,5 @@
 		{#if partyPolitician?.party.name}
 			<br /><span class="text-text-02">พรรค{partyPolitician?.party.name}</span>
 		{/if}
-	</div>
+	</p>
 </div>

--- a/src/components/Proposer/Proposer.svelte
+++ b/src/components/Proposer/Proposer.svelte
@@ -65,13 +65,13 @@
 				alt="{partyPolitician.politician.firstname} {partyPolitician.politician.lastname}"
 				src={partyPolitician.politician.avatar}
 			/>
-		{:else if assembly}
+		{:else}
 			<div class="flex items-center justify-center w-full h-full rounded-full bg-black">
-				<PoliticianIcon class="text-white" />
-			</div>
-		{:else if common}
-			<div class="flex items-center justify-center w-full h-full rounded-full bg-black">
-				<PeopleIcon class="text-white" />
+				{#if assembly}
+					<PoliticianIcon class="text-white" />
+				{:else if common}
+					<PeopleIcon class="text-white" />
+				{/if}
 			</div>
 		{/if}
 	</div>

--- a/src/components/Proposer/Proposer.svelte
+++ b/src/components/Proposer/Proposer.svelte
@@ -2,6 +2,7 @@
 	import PeopleIcon from '$components/icons/PeopleIcon.svelte';
 	import PoliticianIcon from '$components/icons/PoliticianIcon.svelte';
 	import type { Assembly } from '$models/assembly';
+	import type { Party } from '$models/party';
 	import type { Politician } from '$models/politician';
 	import dayjs from 'dayjs';
 
@@ -10,12 +11,18 @@
 		description?: string;
 	};
 
-	export let politician: Politician | undefined = undefined;
+	type PartyPolitician = {
+		politician: Politician;
+		party: Party;
+	};
+
+	export let partyPolitician: PartyPolitician | undefined = undefined;
 	export let assembly: Assembly | undefined = undefined;
 	export let common: CommonProposer | undefined = undefined;
 
 	$: proposerName = () => {
-		if (politician) {
+		if (partyPolitician) {
+			const { politician } = partyPolitician;
 			return [politician.prefix ?? '', politician.firstname, politician.lastname].join(' ');
 		} else if (assembly) {
 			return assembly.name;
@@ -35,29 +42,33 @@
 	};
 </script>
 
-<div class="flex flex-col sm:flex-row items-start sm:items-center">
-	<div class="w-6 h-6">
-		<!-- <img
-			class="w-full h-full rounded-full object-cover"
-			loading="lazy"
-			decoding="async"
-			alt="proposer avatar"
-		/> -->
-		{#if assembly}
+<div class="flex flex-col sm:flex-row justify-start items-start">
+	<div class="w-6 h-6 mb-1">
+		{#if partyPolitician}
+			<img
+				class="w-full h-full rounded-full object-cover"
+				loading="lazy"
+				decoding="async"
+				alt={`${partyPolitician.politician.firstname} ${partyPolitician.politician.lastname}`}
+				src={partyPolitician.politician.avatar}
+			/>
+		{:else if assembly}
 			<div class="flex items-center justify-center w-full h-full rounded-full bg-black">
 				<PoliticianIcon class="text-white" />
 			</div>
-		{/if}
-		{#if common}
+		{:else if common}
 			<div class="flex items-center justify-center w-full h-full rounded-full bg-black">
 				<PeopleIcon class="text-white" />
 			</div>
 		{/if}
 	</div>
-	<div class="mt-1 sm:ml-1 break-words">
+	<div class="sm:ml-1 break-words">
 		<span class="text-text-01">{proposerName()} {proposerTerm()}</span>
 		{#if common?.description}
 			<span class="text-text-02">{common.description}</span>
+		{/if}
+		{#if partyPolitician?.party.name}
+			<br /><span class="text-text-02">พรรค{partyPolitician?.party.name}</span>
 		{/if}
 	</div>
 </div>

--- a/src/components/Proposer/Proposer.svelte
+++ b/src/components/Proposer/Proposer.svelte
@@ -2,6 +2,7 @@
 	import PeopleIcon from '$components/icons/PeopleIcon.svelte';
 	import PoliticianIcon from '$components/icons/PoliticianIcon.svelte';
 	import type { Assembly } from '$models/assembly';
+	import type { Politician } from '$models/politician';
 	import dayjs from 'dayjs';
 
 	type CommonProposer = {
@@ -9,11 +10,14 @@
 		description?: string;
 	};
 
+	export let politician: Politician | undefined = undefined;
 	export let assembly: Assembly | undefined = undefined;
 	export let common: CommonProposer | undefined = undefined;
 
 	$: proposerName = () => {
-		if (assembly) {
+		if (politician) {
+			return [politician.prefix ?? '', politician.firstname, politician.lastname].join(' ');
+		} else if (assembly) {
 			return assembly.name;
 		} else if (common) {
 			return common.name;

--- a/src/components/Proposer/Proposer.svelte
+++ b/src/components/Proposer/Proposer.svelte
@@ -1,0 +1,1 @@
+Proposer

--- a/src/components/Proposer/Proposer.svelte
+++ b/src/components/Proposer/Proposer.svelte
@@ -1,1 +1,17 @@
-Proposer
+<script lang="ts">
+</script>
+
+<div class="flex flex-col sm:flex-row sm:items-center">
+	<div class="w-6 h-6">
+		<img
+			class="w-full h-full rounded-full object-cover"
+			loading="lazy"
+			decoding="async"
+			alt="proposer avatar"
+		/>
+	</div>
+	<div class="mt-1 sm:ml-1 break-words">
+		<span>very long name</span>
+		<span>description </span>
+	</div>
+</div>

--- a/src/components/Proposer/Proposer.svelte
+++ b/src/components/Proposer/Proposer.svelte
@@ -77,11 +77,12 @@
 	</div>
 	<p class="body-01 sm:ml-1 break-words">
 		<span class="text-text-01">{proposerName()} {proposerTerm()}</span>
+		<br class="sm:hidden" />
 		{#if common?.description}
 			<span class="text-text-02">{common.description}</span>
 		{/if}
 		{#if partyPolitician?.party.name}
-			<br /><span class="text-text-02">พรรค{partyPolitician?.party.name}</span>
+			<span class="text-text-02">พรรค{partyPolitician?.party.name}</span>
 		{/if}
 	</p>
 </div>

--- a/src/mocks/data/politician.ts
+++ b/src/mocks/data/politician.ts
@@ -1,0 +1,27 @@
+import type { Politician } from '../../models/politician';
+import { movingForwardParty } from './party';
+
+export const movingForwardPolitician: Politician = {
+	id: '1',
+	avatar: 'https://via.placeholder.com/64',
+	firstname: 'พริษฐ์',
+	lastname: 'วัชรสินธุ',
+	isActive: true,
+	sex: 'male',
+	birthdate: new Date('10/12/1992'),
+	educations: [
+		'ปริญญาตรี สาขา ปรัชญา การเมือง เศรษฐศาสตร์ (เกียรตินิยมอันดับ 1 เหรียญทอง) - University of Oxford (2011-15)'
+	],
+	previousOccupations: ['CEO - StartDee', 'Management Consultant - McKinsey & Company'],
+	assetValue: 10000000,
+	debtValue: 10000000,
+	contacts: [],
+	assemblyRoles: [],
+	partyRoles: [
+		{
+			party: movingForwardParty,
+			role: 'Policy Campaign Manager',
+			startedAt: new Date('01/01/2022')
+		}
+	]
+};


### PR DESCRIPTION
### Description
- Implemented `Proposer` for normal screen and mobile screen.
<img width="427" alt="Screenshot 2566-10-13 at 10 59 02" src="https://github.com/wevisdemo/parliament-watch/assets/14361087/e76d4986-701a-48f2-a261-e015a4874d10">
<img width="276" alt="Screenshot 2566-10-13 at 11 00 27" src="https://github.com/wevisdemo/parliament-watch/assets/14361087/f74ee95a-e766-43c5-adf6-1748c708dac6">

- `Proposer` supports 3 types of proposer, which is seperated to 3 properties. (I think union types up to 1 with type guard is too complicated. 🤮)
  - `Politician` as party, from Figma I found out that it is also requires `Assembly` (สส. ชุดที่ xxx) in order to make it complete. I've packed 3 things up as `PartyPolitician`
  - `Assembly`
  - Other proposers as `CommonProposer` with `name` and `description`