### PR TITLE
Fix #38 Incorrect DataPage's filter and NavigationBar z-index alignment

### DIFF
--- a/src/components/DataPage/DataPage.svelte
+++ b/src/components/DataPage/DataPage.svelte
@@ -159,7 +159,7 @@
 	<div class="flex-1 flex gap-1 bg-ui-01 w-full">
 		{#if showFilter}
 			<div
-				class="fixed w-full h-screen md:h-auto md:max-h-screen overscroll-none md:sticky top-0 flex flex-col bg-white md:w-[250px] flex-[0_0_250px] z-10"
+				class="fixed w-full h-screen md:h-auto md:max-h-screen overscroll-none md:sticky top-0 flex flex-col bg-white md:w-[250px] flex-[0_0_250px] z-50 md:z-30"
 				class:md:flex={!mounted}
 				class:hidden={!mounted}
 			>

--- a/src/components/DataPage/DataPage.svelte
+++ b/src/components/DataPage/DataPage.svelte
@@ -239,6 +239,7 @@
 		{:else}
 			<div class="fixed left-4 bottom-14 z-20">
 				<Button
+					class={isFilterNotDefault ? 'bg-interactive-02' : 'bg-interactive-01'}
 					tooltipAlignment="start"
 					tooltipPosition="top"
 					iconDescription="แสดงตัวเลือก"

--- a/src/components/DataPage/DataPage.svelte
+++ b/src/components/DataPage/DataPage.svelte
@@ -117,7 +117,17 @@
 		mounted = true;
 		showFilter = window.matchMedia(`(min-width: 672px)`).matches;
 	});
+
+	let previousFromTop = 0;
+	let showHeader = true;
+	function scrollEventHandler() {
+		const currentFromTop = window.scrollY;
+		showHeader = currentFromTop <= previousFromTop;
+		previousFromTop = currentFromTop;
+	}
 </script>
+
+<svelte:window on:scroll|passive={scrollEventHandler} />
 
 <div class="flex flex-col min-h-screen">
 	<Breadcrumb
@@ -163,7 +173,10 @@
 				class:md:flex={!mounted}
 				class:hidden={!mounted}
 			>
-				<div class="sticky top-0 flex w-full pl-6">
+				<div
+					class="sticky top-0 md:top-12 flex w-full pl-6 duration-300 z-30 bg-white"
+					class:md:top-12={showHeader}
+				>
 					<Search
 						class="flex-1 {!mounted ? '-mt-6' : ''}"
 						placeholder="ชื่อมติ หรือ คำที่เกี่ยวข้อง"

--- a/src/components/NavigationBar/SideMenuPane.svelte
+++ b/src/components/NavigationBar/SideMenuPane.svelte
@@ -11,7 +11,7 @@
 
 {#if isActive}
 	<aside
-		class="fixed top-0 left-0 h-full pt-12 text-white bg-gray-90 z-10 w-screen md:w-80 opacity-100 transition-all duration-200 overflow-hidden overflow-y-auto"
+		class="fixed top-0 left-0 h-full pt-12 text-white bg-gray-90 z-40 w-screen md:w-80 opacity-100 transition-all duration-200 overflow-hidden overflow-y-auto"
 		transition:slide={{ duration: 350, axis: 'x' }}
 	>
 		<div class="pt-2 pr-2">


### PR DESCRIPTION
Fixes #38 

- The filter button now have `interactive-01` color (with the default filter, or `interactive-02` color otherwise) 
  (Using `class` attributes because tailwind force transparent background on button)
- The filter button is now behind the sidebar
- The filter panel is now behind the navigation bar on mobile screen size
  - On desktop, The filter input (top part of the filter panel) will now aware of navigation bar position (or more accurately, it will leave a space on top when scroll up to prevent itself from being hidden behind navigation bar)

### Mobile filter panel

[Kapture 2023-10-22 at 20.08.29.webm](https://github.com/wevisdemo/parliament-watch/assets/29707893/a057a15e-ce4f-494c-8193-29e17f28f1a0)

### Desktop filter panel

[Kapture 2023-10-22 at 20.19.09.webm](https://github.com/wevisdemo/parliament-watch/assets/29707893/c6a08a34-d076-4d34-8016-e08113d211c3)
