### PR TITLE
Proper Handling SEO tags

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -4,36 +4,10 @@
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-		<title>Parliament Watch - ขับเคลื่อนประชาธิปไตย ร่วมเฝ้าดูความเคลื่อนไหวรัฐสภา</title>
-
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 
 		%sveltekit.head%
-
-		<!-- HTML Meta Tags -->
-		<meta name="description" content="ติดตามกฎหมาย นโยบาย และการทำงานของนักการเมือง" />
-
-		<!-- Facebook Meta Tags -->
-		<meta property="og:url" content="https://parliament-watch.pages.dev/" />
-		<meta property="og:type" content="website" />
-		<meta
-			property="og:title"
-			content="Parliament Watch - ขับเคลื่อนประชาธิปไตย ร่วมเฝ้าดูความเคลื่อนไหวรัฐสภา"
-		/>
-		<meta property="og:description" content="ติดตามกฎหมาย นโยบาย และการทำงานของนักการเมือง" />
-		<meta property="og:image" content="https://parliamentwatch.wevis.info/images/og.png" />
-
-		<!-- Twitter Meta Tags -->
-		<meta name="twitter:card" content="summary_large_image" />
-		<meta property="twitter:domain" content="parliament-watch.pages.dev" />
-		<meta property="twitter:url" content="https://parliament-watch.pages.dev/" />
-		<meta
-			name="twitter:title"
-			content="Parliament Watch - ขับเคลื่อนประชาธิปไตย ร่วมเฝ้าดูความเคลื่อนไหวรัฐสภา"
-		/>
-		<meta name="twitter:description" content="ติดตามกฎหมาย นโยบาย และการทำงานของนักการเมือง" />
-		<meta name="twitter:image" content="https://parliamentwatch.wevis.info/images/og.png" />
 
 		<link rel="apple-touch-icon" sizes="180x180" href="%sveltekit.assets%/apple-touch-icon.png" />
 		<link rel="icon" type="image/png" sizes="32x32" href="%sveltekit.assets%/favicon-32x32.png" />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,13 +5,12 @@
 	import Footer from '$components/Footer/Footer.svelte';
 	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
+	import { DEFAULT_SEO } from '../utils/seo';
 
-	$: title =
-		$page.data?.seo?.title ??
-		'Parliament Watch - ขับเคลื่อนประชาธิปไตย ร่วมเฝ้าดูความเคลื่อนไหวรัฐสภา';
-	$: description = $page.data?.seo?.description ?? 'ติดตามกฎหมาย นโยบาย และการทำงานของนักการเมือง';
-	$: url = new URL($page.route.id ?? '/', 'https://parliamentwatch.wevis.info/').href;
-	$: og = $page.data?.seo?.og ?? 'https://parliamentwatch.wevis.info/images/og.png';
+	$: title = $page.data?.seo?.title ?? DEFAULT_SEO.title;
+	$: description = $page.data?.seo?.description ?? DEFAULT_SEO.description;
+	$: url = new URL($page.url.pathname, 'https://parliamentwatch.wevis.info/').href;
+	$: og = $page.data?.seo?.og ?? DEFAULT_SEO.og;
 
 	onMount(() => {
 		document.querySelectorAll('link.lazy').forEach((el) => el.setAttribute('media', 'all'));

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -7,7 +7,9 @@
 	import { page } from '$app/stores';
 	import { DEFAULT_SEO } from '../utils/seo';
 
-	$: title = $page.data?.seo?.title ?? DEFAULT_SEO.title;
+	$: title = $page.data?.seo?.title
+		? `${$page.data?.seo?.title} - Parliament Watch`
+		: DEFAULT_SEO.title;
 	$: description = $page.data?.seo?.description ?? DEFAULT_SEO.description;
 	$: url = new URL($page.url.pathname, 'https://parliamentwatch.wevis.info/').href;
 	$: og = $page.data?.seo?.og ?? DEFAULT_SEO.og;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,11 +4,36 @@
 	import { InlineNotification } from 'carbon-components-svelte';
 	import Footer from '$components/Footer/Footer.svelte';
 	import { onMount } from 'svelte';
+	import { page } from '$app/stores';
+
+	$: title =
+		$page.data?.seo?.title ??
+		'Parliament Watch - ขับเคลื่อนประชาธิปไตย ร่วมเฝ้าดูความเคลื่อนไหวรัฐสภา';
+	$: description = $page.data?.seo?.description ?? 'ติดตามกฎหมาย นโยบาย และการทำงานของนักการเมือง';
+	$: url = new URL($page.route.id ?? '/', 'https://parliamentwatch.wevis.info/').href;
+	$: og = $page.data?.seo?.og ?? 'https://parliamentwatch.wevis.info/images/og.png';
 
 	onMount(() => {
 		document.querySelectorAll('link.lazy').forEach((el) => el.setAttribute('media', 'all'));
 	});
 </script>
+
+<svelte:head>
+	<title>{title}</title>
+	<meta name="description" content={description} />
+
+	<meta property="og:title" content={title} />
+	<meta property="og:type" content="website" />
+	<meta property="og:image" content={og} />
+	<meta property="og:url" content={url} />
+	<meta property="og:description" content={description} />
+
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:creator" content="@wevisdemo" />
+	<meta name="twitter:title" content={title} />
+	<meta name="twitter:description" content={description} />
+	<meta name="twitter:image" content={og} />
+</svelte:head>
 
 <main class="min-h-screen flex flex-col">
 	<NavigationBar />

--- a/src/routes/about/+page.server.ts
+++ b/src/routes/about/+page.server.ts
@@ -1,3 +1,5 @@
+import { createSeo } from '../../utils/seo.js';
+
 interface ContributorResponse {
 	login: string;
 	html_url: string;
@@ -16,6 +18,9 @@ export async function load({ fetch }) {
 	}));
 
 	return {
-		developers
+		developers,
+		seo: createSeo({
+			title: `เกี่ยวกับเว็บไซต์นี้ - Parliament Watch`
+		})
 	};
 }

--- a/src/routes/about/+page.server.ts
+++ b/src/routes/about/+page.server.ts
@@ -20,7 +20,7 @@ export async function load({ fetch }) {
 	return {
 		developers,
 		seo: createSeo({
-			title: `เกี่ยวกับเว็บไซต์นี้ - Parliament Watch`
+			title: 'เกี่ยวกับเว็บไซต์นี้'
 		})
 	};
 }

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -46,10 +46,6 @@
 	});
 </script>
 
-<svelte:head>
-	<title>เกี่ยวกับเว็บไซต์นี้ - Parliament Watch</title>
-</svelte:head>
-
 <div class="h-[160px] flex items-center justify-center">
 	<h1 class="fluid-heading-05 font-bold">เกี่ยวกับเรา</h1>
 </div>

--- a/src/routes/assemblies/[id]/+page.server.ts
+++ b/src/routes/assemblies/[id]/+page.server.ts
@@ -129,7 +129,7 @@ export async function load({ params }) {
 		mainMembers,
 		latestVotes,
 		seo: createSeo({
-			title: `${assembly.name} ${assembly.term} - Parliament Watch`
+			title: `${assembly.name} ${assembly.term}`
 		})
 	};
 }

--- a/src/routes/assemblies/[id]/+page.server.ts
+++ b/src/routes/assemblies/[id]/+page.server.ts
@@ -6,6 +6,7 @@ import { DefaultVotingResult, type Voting } from '$models/voting';
 import { fetchAssemblies, fetchFromIdOr404 } from '$lib/datasheets';
 import { fetchAssemblyMembers } from './data';
 import { getMemberGroup } from './members/[groupby]/groupby';
+import { createSeo } from '../../../utils/seo';
 
 export interface Summary {
 	totalMembers: number;
@@ -126,6 +127,9 @@ export async function load({ params }) {
 		assembly,
 		summary,
 		mainMembers,
-		latestVotes
+		latestVotes,
+		seo: createSeo({
+			title: `${assembly.name} ${assembly.term} - Parliament Watch`
+		})
 	};
 }

--- a/src/routes/assemblies/[id]/+page.svelte
+++ b/src/routes/assemblies/[id]/+page.svelte
@@ -42,9 +42,6 @@
 	};
 </script>
 
-<svelte:head>
-	<title>{data.assembly.name} {data.assembly.term} - Parliament Watch</title>
-</svelte:head>
 <div class="md:px-[64px] px-[16px]">
 	<Breadcrumb
 		noTrailingSlash

--- a/src/routes/assemblies/[id]/members/[groupby]/+page.server.ts
+++ b/src/routes/assemblies/[id]/members/[groupby]/+page.server.ts
@@ -3,6 +3,7 @@ import { getMemberGroup, type PoliticianSubGroup, type PoliticianGroup } from '.
 import { fetchAssemblies, fetchFromIdOr404 } from '$lib/datasheets';
 import { AssemblyName, GroupByOption } from '$models/assembly';
 import { fetchAssemblyMembers, getPoliticianSummary, type PoliticianSummary } from '../../data';
+import { createSeo } from '../../../../../utils/seo';
 
 interface PoliticianSummaryGroup {
 	name: string;
@@ -46,7 +47,14 @@ export async function load({ params }) {
 
 		const assemblyIds: string[] = (await fetchAssemblies()).map(({ id }) => id);
 
-		return { groups: transformedGroup, isDataHasSubgroup, assemblyIds };
+		return {
+			groups: transformedGroup,
+			isDataHasSubgroup,
+			assemblyIds,
+			seo: createSeo({
+				title: `สมาชิก ${assembly.name} ${assembly.term} - Parliament Watch`
+			})
+		};
 	} else {
 		throw error(404);
 	}

--- a/src/routes/assemblies/[id]/members/[groupby]/+page.server.ts
+++ b/src/routes/assemblies/[id]/members/[groupby]/+page.server.ts
@@ -52,7 +52,7 @@ export async function load({ params }) {
 			isDataHasSubgroup,
 			assemblyIds,
 			seo: createSeo({
-				title: `สมาชิก ${assembly.name} ${assembly.term} - Parliament Watch`
+				title: `สมาชิก ${assembly.name} ${assembly.term}`
 			})
 		};
 	} else {

--- a/src/routes/assemblies/[id]/members/[groupby]/+page.svelte
+++ b/src/routes/assemblies/[id]/members/[groupby]/+page.svelte
@@ -103,10 +103,6 @@
 	});
 </script>
 
-<svelte:head>
-	<title>สมาชิก {data.assembly.name} {data.assembly.term} - Parliament Watch</title>
-</svelte:head>
-
 <Header {data} bind:searchQuery {mounted} {assemblyIds} />
 <Tab {data} />
 <div class="relative flex">

--- a/src/routes/assemblies/[id]/votes/+page.server.ts
+++ b/src/routes/assemblies/[id]/votes/+page.server.ts
@@ -3,6 +3,7 @@ import type { Assembly } from '$models/assembly';
 import { mockCategory, passedVoting } from '../../../../mocks/data/voting.js';
 import { fetchAssemblies } from '$lib/datasheets/index.js';
 import { error } from '@sveltejs/kit';
+import { createSeo } from '../../../../utils/seo.js';
 
 export type VoteSummary = Pick<Voting, 'id' | 'title' | 'result' | 'date' | 'files' | 'categories'>;
 
@@ -37,6 +38,9 @@ export async function load({ params }) {
 	return {
 		assemblyIds,
 		assembly,
-		votes
+		votes,
+		seo: createSeo({
+			title: `การลงมติ ${assembly.name} ${assembly.term} - Parliament Watch`
+		})
 	};
 }

--- a/src/routes/assemblies/[id]/votes/+page.server.ts
+++ b/src/routes/assemblies/[id]/votes/+page.server.ts
@@ -40,7 +40,7 @@ export async function load({ params }) {
 		assembly,
 		votes,
 		seo: createSeo({
-			title: `การลงมติ ${assembly.name} ${assembly.term} - Parliament Watch`
+			title: `การลงมติ ${assembly.name} ${assembly.term}`
 		})
 	};
 }

--- a/src/routes/assemblies/[id]/votes/+page.svelte
+++ b/src/routes/assemblies/[id]/votes/+page.svelte
@@ -27,10 +27,6 @@
 	};
 </script>
 
-<svelte:head>
-	<title>การลงมติ {data.assembly.name} {data.assembly.term} - Parliament Watch</title>
-</svelte:head>
-
 <div>
 	<div class="px-[16px] py-[8px]">
 		<Breadcrumb noTrailingSlash class="[&>.bx--breadcrumb]:flex [&>.bx--breadcrumb]:flex-wrap">

--- a/src/routes/bills/[id]/+page.server.ts
+++ b/src/routes/bills/[id]/+page.server.ts
@@ -108,7 +108,7 @@ export function load({ params }) {
 		mergedIntoBillLatestEvent,
 		relatedVotingResults, // Info of votings in events
 		seo: createSeo({
-			title: `${bill.nickname} - Parliament Watch`
+			title: bill.nickname
 		})
 	};
 }

--- a/src/routes/bills/[id]/+page.server.ts
+++ b/src/routes/bills/[id]/+page.server.ts
@@ -17,6 +17,7 @@ import {
 	royalAssentEvent
 } from '../../../mocks/data/event.js';
 import { failedVoting, passedVoting } from '../../../mocks/data/voting.js';
+import { createSeo } from '../../../utils/seo.js';
 
 export interface VotingResultSummary {
 	agreed: number;
@@ -105,7 +106,10 @@ export function load({ params }) {
 		events,
 		mergedIntoBill, // The bill that this bill got merged into. (merged event)
 		mergedIntoBillLatestEvent,
-		relatedVotingResults // Info of votings in events
+		relatedVotingResults, // Info of votings in events
+		seo: createSeo({
+			title: `${bill.nickname} - Parliament Watch`
+		})
 	};
 }
 

--- a/src/routes/bills/[id]/+page.svelte
+++ b/src/routes/bills/[id]/+page.svelte
@@ -91,11 +91,8 @@
 	$: innerWidth = 0;
 </script>
 
-<svelte:head>
-	<title>{bill.nickname} - Parliament Watch</title>
-</svelte:head>
-
 <svelte:window bind:innerWidth />
+
 <Breadcrumb
 	noTrailingSlash
 	class="px-4 py-2 body-compact-01 [&>.bx--breadcrumb]:flex [&>.bx--breadcrumb]:flex-wrap"

--- a/src/routes/legislative-process/+page.server.ts
+++ b/src/routes/legislative-process/+page.server.ts
@@ -284,7 +284,7 @@ export function load() {
 		},
 		legislations,
 		seo: createSeo({
-			title: 'รัฐออกกฎหมายอย่างไร - Parliament Watch'
+			title: 'รัฐออกกฎหมายอย่างไร'
 		})
 	};
 }

--- a/src/routes/legislative-process/+page.server.ts
+++ b/src/routes/legislative-process/+page.server.ts
@@ -1,3 +1,5 @@
+import { createSeo } from '../../utils/seo';
+
 export interface DutySection {
 	heading: string;
 	details: string[];
@@ -280,6 +282,9 @@ export function load() {
 			senates,
 			both
 		},
-		legislations
+		legislations,
+		seo: createSeo({
+			title: 'รัฐออกกฎหมายอย่างไร - Parliament Watch'
+		})
 	};
 }

--- a/src/routes/legislative-process/+page.svelte
+++ b/src/routes/legislative-process/+page.svelte
@@ -159,10 +159,6 @@
 	});
 </script>
 
-<svelte:head>
-	<title>รัฐออกกฎหมายอย่างไร - Parliament Watch</title>
-</svelte:head>
-
 <div class="flex flex-col w-full">
 	<header class="bg-teal-20">
 		<div class="w-full max-w-[800px] px-10 py-10 md:py-20 mx-auto">

--- a/src/routes/politicians/[id]/+page.server.ts
+++ b/src/routes/politicians/[id]/+page.server.ts
@@ -48,7 +48,7 @@ export async function load({ params }) {
 		votingAbsentStats,
 		totalProposedBill: 6,
 		seo: createSeo({
-			title: `${politician.firstname} ${politician.lastname} - Parliament Watch`
+			title: `${politician.firstname} ${politician.lastname}`
 		})
 	};
 }

--- a/src/routes/politicians/[id]/+page.server.ts
+++ b/src/routes/politicians/[id]/+page.server.ts
@@ -1,6 +1,7 @@
 import type { Voting } from '$models/voting';
 import { failedVoting, passedVoting } from '../../../mocks/data/voting';
 import { fetchFromIdOr404, fetchPoliticians } from '$lib/datasheets';
+import { createSeo } from '../../../utils/seo';
 
 interface VotingHistory {
 	total: number;
@@ -45,6 +46,9 @@ export async function load({ params }) {
 		agreedVoting,
 		disagreedVoting,
 		votingAbsentStats,
-		totalProposedBill: 6
+		totalProposedBill: 6,
+		seo: createSeo({
+			title: `${politician.firstname} ${politician.lastname} - Parliament Watch`
+		})
 	};
 }

--- a/src/routes/politicians/[id]/+page.svelte
+++ b/src/routes/politicians/[id]/+page.svelte
@@ -48,10 +48,6 @@
 	});
 </script>
 
-<svelte:head>
-	<title>{politician.firstname} {politician.lastname} - Parliament Watch</title>
-</svelte:head>
-
 <Breadcrumb
 	noTrailingSlash
 	class="px-4 py-2 body-compact-01 [&>.bx--breadcrumb]:flex [&>.bx--breadcrumb]:flex-wrap"

--- a/src/routes/politicians/[id]/votes/+page.server.ts
+++ b/src/routes/politicians/[id]/votes/+page.server.ts
@@ -71,7 +71,7 @@ export async function load({ params }) {
 		filterOptions,
 		votes,
 		seo: createSeo({
-			title: `ประวัติการลงมติ ${politicianSummary.firstname} ${politicianSummary.lastname} - Parliament Watch`
+			title: `ประวัติการลงมติ ${politicianSummary.firstname} ${politicianSummary.lastname}`
 		})
 	};
 }

--- a/src/routes/politicians/[id]/votes/+page.server.ts
+++ b/src/routes/politicians/[id]/votes/+page.server.ts
@@ -13,6 +13,7 @@ import {
 	passedVoting
 } from '../../../../mocks/data/voting.js';
 import { fetchAssemblies, fetchFromIdOr404, fetchPoliticians } from '$lib/datasheets';
+import { createSeo } from '../../../../utils/seo.js';
 
 interface VoteSummary
 	extends Pick<
@@ -68,6 +69,9 @@ export async function load({ params }) {
 	return {
 		politician: politicianSummary,
 		filterOptions,
-		votes
+		votes,
+		seo: createSeo({
+			title: `ประวัติการลงมติ ${politicianSummary.firstname} ${politicianSummary.lastname} - Parliament Watch`
+		})
 	};
 }

--- a/src/routes/politicians/[id]/votes/+page.svelte
+++ b/src/routes/politicians/[id]/votes/+page.svelte
@@ -110,10 +110,6 @@
 	});
 </script>
 
-<svelte:head>
-	<title>ประวัติการลงมติ {politician.firstname} {politician.lastname} - Parliament Watch</title>
-</svelte:head>
-
 <DataPage
 	breadcrumbList={[
 		{ url: '/', label: 'หน้าหลัก' },

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -1,0 +1,13 @@
+export interface Seo {
+	title: string;
+	description: string;
+	og: string;
+}
+
+export const createSeo = (data: Partial<Seo>): Seo => {
+	return {
+		title: data.title ?? 'Parliament Watch - ขับเคลื่อนประชาธิปไตย ร่วมเฝ้าดูความเคลื่อนไหวรัฐสภา',
+		description: data.description ?? 'ติดตามกฎหมาย นโยบาย และการทำงานของนักการเมือง',
+		og: data.og ?? 'https://parliamentwatch.wevis.info/images/og.png'
+	};
+};

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -4,10 +4,16 @@ export interface Seo {
 	og: string;
 }
 
+export const DEFAULT_SEO = {
+	title: 'Parliament Watch - ขับเคลื่อนประชาธิปไตย ร่วมเฝ้าดูความเคลื่อนไหวรัฐสภา',
+	description: 'ติดตามกฎหมาย นโยบาย และการทำงานของนักการเมือง',
+	og: 'https://parliamentwatch.wevis.info/images/og.png'
+};
+
 export const createSeo = (data: Partial<Seo>): Seo => {
 	return {
-		title: data.title ?? 'Parliament Watch - ขับเคลื่อนประชาธิปไตย ร่วมเฝ้าดูความเคลื่อนไหวรัฐสภา',
-		description: data.description ?? 'ติดตามกฎหมาย นโยบาย และการทำงานของนักการเมือง',
-		og: data.og ?? 'https://parliamentwatch.wevis.info/images/og.png'
+		title: data.title ?? DEFAULT_SEO.title,
+		description: data.description ?? DEFAULT_SEO.description,
+		og: data.og ?? DEFAULT_SEO.og
 	};
 };

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -12,7 +12,7 @@ export const DEFAULT_SEO = {
 
 export const createSeo = (data: Partial<Seo>): Seo => {
 	return {
-		title: data.title ?? DEFAULT_SEO.title,
+		title: data.title ? `${data.title} - Parliament Watch` : DEFAULT_SEO.title,
 		description: data.description ?? DEFAULT_SEO.description,
 		og: data.og ?? DEFAULT_SEO.og
 	};


### PR DESCRIPTION
From a common pattern in [the documentation](https://kit.svelte.dev/docs/seo#manual-setup-title-and-meta), I've moved SEO-related tags into the main `+layout.svelte` and return the formatted SEO data from each page's `+page.ts`. To make formatting easier, I've created a helper function called `createSeo()` to help you properly format the SEO data.