### PR TITLE
feat(promise): promise detail - clarification logs

### DIFF
--- a/src/components/PromiseDetail/PromiseClarificationAnswer.svelte
+++ b/src/components/PromiseDetail/PromiseClarificationAnswer.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import { formatThaiDate } from '$lib/date-parser';
+	import type { PromiseClarificationLog } from '$models/promise';
+	import { Quotes } from 'carbon-icons-svelte';
+
+	export let clarificationAnswer: PromiseClarificationLog['answer'];
+	export let partyName: string;
+</script>
+
+{#if !clarificationAnswer}
+	<div></div>
+{:else}
+	<div class="py-2">
+		<div class="flex flex-row gap-2 text-text-03">
+			<Quotes class="text-2xl" size={20} />
+			<span>
+				คำชี้แจงจากพรรค{partyName} ({formatThaiDate(clarificationAnswer.date, true)})
+			</span>
+		</div>
+		<div class="flex flex-row gap-2">
+			<div class="vertical-gray-line" />
+			<div class="body-02 font-semibold text-text-01">
+				{clarificationAnswer.content}
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style lang="postcss">
+	.vertical-gray-line {
+		@apply mx-2 min-h-full border-solid border-gray-20 md:border-[1px];
+	}
+</style>

--- a/src/components/PromiseDetail/PromiseClarificationAnswer.svelte
+++ b/src/components/PromiseDetail/PromiseClarificationAnswer.svelte
@@ -3,28 +3,24 @@
 	import type { PromiseClarificationLog } from '$models/promise';
 	import { Quotes } from 'carbon-icons-svelte';
 
-	export let clarificationAnswer: PromiseClarificationLog['answer'];
+	export let clarificationAnswer: NonNullable<PromiseClarificationLog['answer']>;
 	export let partyName: string;
 </script>
 
-{#if !clarificationAnswer}
-	<div></div>
-{:else}
-	<div class="py-2">
-		<div class="flex flex-row gap-2 text-text-03">
-			<Quotes class="text-2xl" size={20} />
-			<span>
-				คำชี้แจงจากพรรค{partyName} ({formatThaiDate(clarificationAnswer.date, true)})
-			</span>
-		</div>
-		<div class="flex flex-row gap-2">
-			<div class="vertical-gray-line" />
-			<div class="body-02 font-semibold text-text-01">
-				{clarificationAnswer.content}
-			</div>
+<div class="py-2">
+	<div class="flex flex-row gap-2 text-text-03">
+		<Quotes class="text-2xl" size={20} />
+		<span>
+			คำชี้แจงจากพรรค{partyName} ({formatThaiDate(clarificationAnswer.date, true)})
+		</span>
+	</div>
+	<div class="flex flex-row gap-2">
+		<div class="vertical-gray-line" />
+		<div class="body-02 font-semibold text-text-01">
+			{clarificationAnswer.content}
 		</div>
 	</div>
-{/if}
+</div>
 
 <style lang="postcss">
 	.vertical-gray-line {

--- a/src/components/PromiseDetail/PromiseClarificationLog.svelte
+++ b/src/components/PromiseDetail/PromiseClarificationLog.svelte
@@ -1,13 +1,25 @@
 <script lang="ts">
 	import { formatThaiDate } from '$lib/date-parser';
 	import type { PromiseClarificationLog } from '$models/promise';
-	import { Quotes } from 'carbon-icons-svelte';
+	import PromiseClarificationAnswer from './PromiseClarificationAnswer.svelte';
 
+	export let partyName: string;
 	export let clarificationLogs: PromiseClarificationLog[] | undefined;
+	$: isClarified = clarificationLogs?.every((log) => !!log.answer);
 </script>
 
 {#if !clarificationLogs || clarificationLogs.length === 0}
 	<div></div>
+{:else if isClarified}
+	<div class="border-2 border-ui-01 bg-ui-01 p-4">
+		<span class="text-text-01"
+			>ทีมงาน WeVis เห็นว่าคำสัญญานี้มีความคลุมเครือ จึงส่งจดหมายเปิดผนึกขอคำชี้แจงไปที่พรรค{partyName}
+			และได้รับคำชี้แจงเพิ่มเติม ดังนี้
+		</span>
+		{#each clarificationLogs as clarificationLog}
+			<PromiseClarificationAnswer {partyName} clarificationAnswer={clarificationLog.answer} />
+		{/each}
+	</div>
 {:else}
 	<div class="border-2 border-ui-01 p-4">
 		<ul class="body-01 flex list-outside list-disc flex-col gap-1 px-4 text-text-02">
@@ -16,25 +28,7 @@
 					<div>
 						<span>{formatThaiDate(clarificationLog.date, true)}</span>
 						<span class="text-text-01">{clarificationLog.title}</span>
-						{#if clarificationLog.answer}
-							<div class="py-4">
-								<div class="flex flex-row gap-2 text-text-03">
-									<Quotes class="text-2xl" size={20} />
-									<span class="py-1">
-										คำชี้แจงจากพรรคเพื่อไทย ({formatThaiDate(
-											clarificationLog.answer.date,
-											true
-										)})</span
-									>
-								</div>
-								<div class="flex flex-row gap-2">
-									<div class="vertical-gray-line" />
-									<div class="body-02 font-semibold text-text-01">
-										{clarificationLog.answer.content}
-									</div>
-								</div>
-							</div>
-						{/if}
+						<PromiseClarificationAnswer {partyName} clarificationAnswer={clarificationLog.answer} />
 					</div>
 				</li>
 			{/each}
@@ -45,9 +39,5 @@
 <style lang="postcss">
 	li::marker {
 		@apply text-xs;
-	}
-
-	.vertical-gray-line {
-		@apply mx-2 min-h-full border-solid border-gray-20 md:border-[1px];
 	}
 </style>

--- a/src/components/PromiseDetail/PromiseClarificationLog.svelte
+++ b/src/components/PromiseDetail/PromiseClarificationLog.svelte
@@ -4,20 +4,20 @@
 	import PromiseClarificationAnswer from './PromiseClarificationAnswer.svelte';
 
 	export let partyName: string;
-	export let clarificationLogs: PromiseClarificationLog[] | undefined;
-	$: isClarified = clarificationLogs?.every((log) => !!log.answer);
+	export let clarificationLogs: PromiseClarificationLog[];
+	$: isClarified = clarificationLogs.every((log) => !!log.answer);
 </script>
 
-{#if !clarificationLogs || clarificationLogs.length === 0}
-	<div></div>
-{:else if isClarified}
+{#if isClarified}
 	<div class="border-2 border-ui-01 bg-ui-01 p-4">
 		<span class="text-text-01"
 			>ทีมงาน WeVis เห็นว่าคำสัญญานี้มีความคลุมเครือ จึงส่งจดหมายเปิดผนึกขอคำชี้แจงไปที่พรรค{partyName}
 			และได้รับคำชี้แจงเพิ่มเติม ดังนี้
 		</span>
 		{#each clarificationLogs as clarificationLog}
-			<PromiseClarificationAnswer {partyName} clarificationAnswer={clarificationLog.answer} />
+			{#if clarificationLog.answer}
+				<PromiseClarificationAnswer {partyName} clarificationAnswer={clarificationLog.answer} />
+			{/if}
 		{/each}
 	</div>
 {:else}
@@ -28,7 +28,12 @@
 					<div>
 						<span>{formatThaiDate(clarificationLog.date, true)}</span>
 						<span class="text-text-01">{clarificationLog.title}</span>
-						<PromiseClarificationAnswer {partyName} clarificationAnswer={clarificationLog.answer} />
+						{#if clarificationLog.answer}
+							<PromiseClarificationAnswer
+								{partyName}
+								clarificationAnswer={clarificationLog.answer}
+							/>
+						{/if}
 					</div>
 				</li>
 			{/each}

--- a/src/components/PromiseDetail/PromiseClarificationLog.svelte
+++ b/src/components/PromiseDetail/PromiseClarificationLog.svelte
@@ -29,7 +29,7 @@
 								</div>
 								<div class="flex flex-row gap-2">
 									<div class="vertical-gray-line" />
-									<div class="body-02 font-semi-bold text-text-01">
+									<div class="body-02 font-semibold text-text-01">
 										{clarificationLog.answer.content}
 									</div>
 								</div>

--- a/src/components/PromiseList/ClarificationLog.svelte
+++ b/src/components/PromiseList/ClarificationLog.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import { formatThaiDate } from '$lib/date-parser';
+	import type { PromiseClarificationLog } from '$models/promise';
+
+	export let clarificationLogs: PromiseClarificationLog[] | undefined;
+	// "clarificationLogs": [
+	//   {
+	//     "date": "2024-08-14T00:00:00.000Z",
+	//     "title": "ทีมงาน WeVis ส่งจดหมายเปิดผนึกขอคำชี้แจงไปที่พรรคเพื่อไทย info@ptp.or.th"
+	//   },
+	//   {
+	//     "date": "2024-08-18T00:00:00.000Z",
+	//     "title": "ทีมงาน WeVis ส่งจดหมายติดตามคำชี้แจงไปที่พรรคเพื่อไทย info@ptp.or.th",
+	//     "answer": {
+	//       "date": "2024-08-20T00:00:00.000Z",
+	//       "content": "Lorem ipsum dolor sit amet consectetur. Tincidunt enim vestibulum nullam auctor volutpat non eget adipiscing. Tortor netus volutpat quam nunc faucibus sed. Sit ornare quam ultricies quisque diam velit dignissim dui integer. Nisi curabitur in mauris id habitasse consequat nec in mi."
+	//     }
+	//   },
+	//   {
+	//     "date": "2024-08-21T00:00:00.000Z",
+	//     "title": "ทีมงาน WeVis เห็นว่าคำสัญญานี้ยังคงคลุมเครือ แม้ว่าได้พิจารณาร่วมกับคำชี้แจ้งที่ได้รับแล้ว ในประเด็นต่อไปนี้ xxx yyy zzz จึงได้ดำเนินการขอคำชี้แจงเพิ่มเติม",
+	//     "answer": {
+	//       "date": "2024-08-22T00:00:00.000Z",
+	//       "content": "Lorem ipsum dolor sit amet consectetur. Tincidunt enim vestibulum nullam auctor volutpat non eget adipiscing. Tortor netus volutpat quam nunc faucibus sed. Sit ornare quam ultricies quisque diam velit dignissim dui integer. Nisi curabitur in mauris id habitasse consequat nec in mi."
+	//     }
+	//   }
+	// ],
+</script>
+
+{#if !clarificationLogs || clarificationLogs.length === 0}
+	<div></div>
+{:else}
+	<div>
+		<ul class="body-01 flex list-outside list-disc flex-col gap-1 text-text-02">
+			{#each clarificationLogs as clarificationLog}
+				<li>
+					<div>
+						<span>{formatThaiDate(clarificationLog.date, true)}</span>
+						<span class="text-text-01">{clarificationLog.title}</span>
+					</div>
+				</li>
+			{/each}
+		</ul>
+	</div>
+{/if}

--- a/src/components/PromiseList/ClarificationLog.svelte
+++ b/src/components/PromiseList/ClarificationLog.svelte
@@ -30,8 +30,8 @@
 {#if !clarificationLogs || clarificationLogs.length === 0}
 	<div></div>
 {:else}
-	<div>
-		<ul class="body-01 flex list-outside list-disc flex-col gap-1 text-text-02">
+	<div class="border-2 border-ui-01 p-4">
+		<ul class="body-01 flex list-outside list-disc flex-col gap-1 px-4 text-text-02">
 			{#each clarificationLogs as clarificationLog}
 				<li>
 					<div>
@@ -43,3 +43,9 @@
 		</ul>
 	</div>
 {/if}
+
+<style lang="postcss">
+	li::marker {
+		@apply text-xs;
+	}
+</style>

--- a/src/components/PromiseList/ClarificationLog.svelte
+++ b/src/components/PromiseList/ClarificationLog.svelte
@@ -1,30 +1,9 @@
 <script lang="ts">
 	import { formatThaiDate } from '$lib/date-parser';
 	import type { PromiseClarificationLog } from '$models/promise';
+	import { Quotes } from 'carbon-icons-svelte';
 
 	export let clarificationLogs: PromiseClarificationLog[] | undefined;
-	// "clarificationLogs": [
-	//   {
-	//     "date": "2024-08-14T00:00:00.000Z",
-	//     "title": "ทีมงาน WeVis ส่งจดหมายเปิดผนึกขอคำชี้แจงไปที่พรรคเพื่อไทย info@ptp.or.th"
-	//   },
-	//   {
-	//     "date": "2024-08-18T00:00:00.000Z",
-	//     "title": "ทีมงาน WeVis ส่งจดหมายติดตามคำชี้แจงไปที่พรรคเพื่อไทย info@ptp.or.th",
-	//     "answer": {
-	//       "date": "2024-08-20T00:00:00.000Z",
-	//       "content": "Lorem ipsum dolor sit amet consectetur. Tincidunt enim vestibulum nullam auctor volutpat non eget adipiscing. Tortor netus volutpat quam nunc faucibus sed. Sit ornare quam ultricies quisque diam velit dignissim dui integer. Nisi curabitur in mauris id habitasse consequat nec in mi."
-	//     }
-	//   },
-	//   {
-	//     "date": "2024-08-21T00:00:00.000Z",
-	//     "title": "ทีมงาน WeVis เห็นว่าคำสัญญานี้ยังคงคลุมเครือ แม้ว่าได้พิจารณาร่วมกับคำชี้แจ้งที่ได้รับแล้ว ในประเด็นต่อไปนี้ xxx yyy zzz จึงได้ดำเนินการขอคำชี้แจงเพิ่มเติม",
-	//     "answer": {
-	//       "date": "2024-08-22T00:00:00.000Z",
-	//       "content": "Lorem ipsum dolor sit amet consectetur. Tincidunt enim vestibulum nullam auctor volutpat non eget adipiscing. Tortor netus volutpat quam nunc faucibus sed. Sit ornare quam ultricies quisque diam velit dignissim dui integer. Nisi curabitur in mauris id habitasse consequat nec in mi."
-	//     }
-	//   }
-	// ],
 </script>
 
 {#if !clarificationLogs || clarificationLogs.length === 0}
@@ -37,6 +16,25 @@
 					<div>
 						<span>{formatThaiDate(clarificationLog.date, true)}</span>
 						<span class="text-text-01">{clarificationLog.title}</span>
+						{#if clarificationLog.answer}
+							<div class="py-4">
+								<div class="flex flex-row gap-2 text-text-03">
+									<Quotes class="text-2xl" size={20} />
+									<span class="py-1">
+										คำชี้แจงจากพรรคเพื่อไทย ({formatThaiDate(
+											clarificationLog.answer.date,
+											true
+										)})</span
+									>
+								</div>
+								<div class="flex flex-row gap-2">
+									<div class="vertical-gray-line" />
+									<div class="body-02 font-semi-bold text-text-01">
+										{clarificationLog.answer.content}
+									</div>
+								</div>
+							</div>
+						{/if}
 					</div>
 				</li>
 			{/each}
@@ -47,5 +45,9 @@
 <style lang="postcss">
 	li::marker {
 		@apply text-xs;
+	}
+
+	.vertical-gray-line {
+		@apply mx-2 min-h-full border-solid border-gray-20 md:border-[1px];
 	}
 </style>

--- a/src/routes/promises/[id]/+page.svelte
+++ b/src/routes/promises/[id]/+page.svelte
@@ -6,7 +6,7 @@
 	import Share from '$components/Share/Share.svelte';
 	import { Breadcrumb, BreadcrumbItem, Button } from 'carbon-components-svelte';
 	import { SendAlt } from 'carbon-icons-svelte';
-	import ClarificationLog from '$components/PromiseList/ClarificationLog.svelte';
+	import PromiseClarificationLog from '$components/PromiseDetail/PromiseClarificationLog.svelte';
 
 	export let data;
 
@@ -67,6 +67,9 @@
 		>
 			ดูความหมายสถานะอื่นๆ
 		</button>
+	</div>
+	<div class="mt-4">
+		<PromiseClarificationLog clarificationLogs={promise.clarificationLogs} />
 	</div>
 	<div class="mt-8 flex flex-col justify-between gap-8 xl:flex-row">
 		<div class="flex flex-col gap-2">

--- a/src/routes/promises/[id]/+page.svelte
+++ b/src/routes/promises/[id]/+page.svelte
@@ -68,12 +68,14 @@
 			ดูความหมายสถานะอื่นๆ
 		</button>
 	</div>
-	<div class="mt-4">
-		<PromiseClarificationLog
-			partyName={promise.party.name}
-			clarificationLogs={promise.clarificationLogs}
-		/>
-	</div>
+	{#if promise.clarificationLogs && promise.clarificationLogs?.length > 0}
+		<div class="mt-4">
+			<PromiseClarificationLog
+				partyName={promise.party.name}
+				clarificationLogs={promise.clarificationLogs}
+			/>
+		</div>
+	{/if}
 	<div class="mt-8 flex flex-col justify-between gap-8 xl:flex-row">
 		<div class="flex flex-col gap-2">
 			<div class="flex flex-wrap gap-1">

--- a/src/routes/promises/[id]/+page.svelte
+++ b/src/routes/promises/[id]/+page.svelte
@@ -6,6 +6,7 @@
 	import Share from '$components/Share/Share.svelte';
 	import { Breadcrumb, BreadcrumbItem, Button } from 'carbon-components-svelte';
 	import { SendAlt } from 'carbon-icons-svelte';
+	import ClarificationLog from '$components/PromiseList/ClarificationLog.svelte';
 
 	export let data;
 

--- a/src/routes/promises/[id]/+page.svelte
+++ b/src/routes/promises/[id]/+page.svelte
@@ -69,7 +69,10 @@
 		</button>
 	</div>
 	<div class="mt-4">
-		<PromiseClarificationLog clarificationLogs={promise.clarificationLogs} />
+		<PromiseClarificationLog
+			partyName={promise.party.name}
+			clarificationLogs={promise.clarificationLogs}
+		/>
 	</div>
 	<div class="mt-8 flex flex-col justify-between gap-8 xl:flex-row">
 		<div class="flex flex-col gap-2">


### PR DESCRIPTION
resolve #102 

It's still WIP but creating this just to list out questions that I have. But feel free to leave out any comment on the code na kub, i'm still not very familiar with the codebase, so there might be something reusable that i miss.

Feature-related questions:
1. it seems like we want to show a clarification log a different way, depends on whether the clarification answer is "good enough". do we have this "good-enough status" in our data model yet?

Development questions:
1. i got a lot of errors running svelte check in pre-push. not sure what i did wrong.

<img width="1177" alt="image" src="https://github.com/user-attachments/assets/6e604982-f2f8-4b5c-a557-4265731cd051">
2. i got this error when running the web and it's causing the whole thing to go `500`

<img width="752" alt="image" src="https://github.com/user-attachments/assets/56f34bb2-fe04-4a36-974c-34abd5e65857">

and the cause seems to be because the `safeFind` is not really safe and still throws an error?

<img width="746" alt="image" src="https://github.com/user-attachments/assets/9acd0884-609a-4cbb-9508-f184c8513e68">


