### PR TITLE
Make votings and bills tables show 50 items per page

### DIFF
--- a/src/components/DataPage/DataPage.svelte
+++ b/src/components/DataPage/DataPage.svelte
@@ -267,9 +267,7 @@
 					class="w-0 min-w-full pt-0"
 					size="tall"
 					headers={tableHeader}
-					rows={filteredData.map((data, index) => {
-						return { ...data, id: `${index}-${data.id}` };
-					})}
+					rows={filteredData}
 					pageSize={tablePageSize}
 					page={tableCurrentPage}
 				>

--- a/src/components/DataPage/DataPage.svelte
+++ b/src/components/DataPage/DataPage.svelte
@@ -267,7 +267,9 @@
 					class="w-0 min-w-full pt-0"
 					size="tall"
 					headers={tableHeader}
-					rows={filteredData}
+					rows={filteredData.map((data, index) => {
+						return { ...data, id: `${index}-${data.id}` };
+					})}
 					pageSize={tablePageSize}
 					page={tableCurrentPage}
 				>

--- a/src/routes/assemblies/[id]/votes/+page.svelte
+++ b/src/routes/assemblies/[id]/votes/+page.svelte
@@ -36,6 +36,7 @@
 </script>
 
 <DataPage
+	tablePageSize={50}
 	breadcrumbList={[
 		{ url: '/', label: 'หน้าหลัก' },
 		{ label: 'นักการเมือง' },
@@ -75,7 +76,7 @@
 			{@const files = cellValue}
 			{#if files.length > 0}
 				<div class="flex flex-wrap gap-2">
-					{#each files as file (file)}
+					{#each files as file, index (index)}
 						<a href={file.url} title={file.label} target="_blank" rel="noopener noreferrer"
 							><DocumentPdf /><span class="sr-only">{file.label}</span></a
 						>

--- a/src/routes/assemblies/[id]/votes/+page.svelte
+++ b/src/routes/assemblies/[id]/votes/+page.svelte
@@ -76,7 +76,7 @@
 			{@const files = cellValue}
 			{#if files.length > 0}
 				<div class="flex flex-wrap gap-2">
-					{#each files as file, index (index)}
+					{#each files as file (file)}
 						<a href={file.url} title={file.label} target="_blank" rel="noopener noreferrer"
 							><DocumentPdf /><span class="sr-only">{file.label}</span></a
 						>

--- a/src/routes/bills/explore/+page.svelte
+++ b/src/routes/bills/explore/+page.svelte
@@ -149,6 +149,7 @@
 
 <DataPage
 	bind:this={cmpDataPage}
+	tablePageSize={50}
 	breadcrumbList={[
 		{ url: '/', label: 'หน้าหลัก' },
 		{ url: '/bills', label: 'ร่างกฎหมายในสภา' },


### PR DESCRIPTION
Resolves https://github.com/wevisdemo/parliament-watch/issues/115
What I did:
- Adjust page size to 50 for `votings` and `bills` page
- I found that the id of some data can crash resulting in the error `Error: Cannot have duplicate keys in a keyed each:` so I map those the data in `DataTable` and give them a unique id to prevent crashing