### PR TITLE
Display invalid status label color in some voting page

### DIFF
--- a/src/routes/votings/[id]/+page.svelte
+++ b/src/routes/votings/[id]/+page.svelte
@@ -115,7 +115,10 @@
 		[DefaultVotingResult.Passed]: 'text-teal-50',
 		[DefaultVoteOption.Agreed]: 'text-teal-50',
 		[DefaultVotingResult.Failed]: 'text-red-50',
-		[DefaultVoteOption.Disagreed]: 'text-red-50'
+		[DefaultVoteOption.Disagreed]: 'text-red-50',
+		[DefaultVoteOption.Novote]: 'gray-80',
+		[DefaultVoteOption.Abstain]: 'gray-50',
+		[DefaultVoteOption.Absent]: 'gray-20'
 	};
 
 	$: voterSearchResult = searchQuery.trim()


### PR DESCRIPTION
Resolves https://github.com/wevisdemo/parliament-watch/issues/114

**What I did**
- Added mappings for missing colors