### PR TITLE
feat: add tooltips in assembly member chart

### DIFF
--- a/src/components/Assemblies/AssemblyTooltip.svelte
+++ b/src/components/Assemblies/AssemblyTooltip.svelte
@@ -6,12 +6,12 @@
 
 {#if tooltipProp}
 	<div
-		style:left="{tooltipProp?.x ?? 0}px"
-		style:top="{tooltipProp?.y ?? 0}px"
+		style:left="{tooltipProp.x}px"
+		style:top="{tooltipProp.y}px"
 		class="label-01 absolute z-10 flex min-w-max flex-col
 		rounded-sm bg-[#393939] p-3 text-center text-white"
 	>
-		<div class="font-semibold">{tooltipProp?.title}</div>
-		<div>{tooltipProp?.additional}</div>
+		<div class="font-semibold">{tooltipProp.title}</div>
+		<div>{tooltipProp.additional}</div>
 	</div>
 {/if}

--- a/src/components/Assemblies/AssemblyTooltip.svelte
+++ b/src/components/Assemblies/AssemblyTooltip.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import type { TooltipProp } from './shared';
+
+	export let tooltipProp: TooltipProp | null = null;
+</script>
+
+{#if tooltipProp}
+	<div
+		style:left="{tooltipProp?.x ?? 0}px"
+		style:top="{tooltipProp?.y ?? 0}px"
+		class="label-01 absolute z-10 flex min-w-max flex-col
+		rounded-sm bg-[#393939] p-3 text-center text-white"
+	>
+		<div class="font-semibold">{tooltipProp?.title}</div>
+		<div>{tooltipProp?.additional}</div>
+	</div>
+{/if}

--- a/src/components/Assemblies/CabinetRole.svelte
+++ b/src/components/Assemblies/CabinetRole.svelte
@@ -1,20 +1,47 @@
 <script lang="ts">
-	import type { CabinetSeat } from './shared';
+	import type { AssemblyMember } from '$lib/datasheets/assembly-member';
+	import AssemblyTooltip from './AssemblyTooltip.svelte';
+	import type { CabinetSeat, TooltipProp } from './shared';
 
 	export let cabinets: CabinetSeat[];
 	export let role: CabinetSeat['role'];
+
+	let tooltipProp: TooltipProp | null = null;
+
+	const showTooltip = (event: MouseEvent, member: AssemblyMember) => {
+		const name = `${member.firstname} ${member.lastname}`;
+
+		tooltipProp = {
+			title: name,
+			additional: member.assemblyRole.role,
+			x: event.layerX,
+			y: event.layerY + 20
+		};
+	};
+
+	const hideTooltip = () => {
+		tooltipProp = null;
+	};
 </script>
 
 <div class="role">
 	<p class="heading-compact-01">{role}</p>
 	<div class="group-dot">
 		{#each cabinets.find((c) => role === c.role)?.parties || [] as party}
-			{#each Array.from({ length: party.count || 0 }, (_, i) => i) as _}
-				<span class="dot" style="background-color: {party.color || '#8D8D8D'};"></span>
+			{#each party?.members ?? [] as member}
+				<div
+					role="tooltip"
+					class="dot"
+					style="background-color: {party.color || '#8D8D8D'};"
+					on:mouseenter={(e) => showTooltip(e, member)}
+					on:mouseleave={hideTooltip}
+				></div>
 			{/each}
 		{/each}
 	</div>
 </div>
+
+<AssemblyTooltip {tooltipProp}></AssemblyTooltip>
 
 <style lang="scss">
 	.group-dot {

--- a/src/components/Assemblies/SummaryTotal.svelte
+++ b/src/components/Assemblies/SummaryTotal.svelte
@@ -17,7 +17,12 @@
 			if (foundParty) {
 				foundParty.count += party.count;
 			} else {
-				acc.push({ name: party.name, count: party.count, color: party.color });
+				acc.push({
+					name: party.name,
+					count: party.count,
+					color: party.color,
+					members: party.members
+				});
 			}
 			return acc;
 		}, []);
@@ -60,7 +65,8 @@
 			return {
 				name: group.name,
 				count: group.total,
-				color: getSenateColorByTitle(group.name)
+				color: getSenateColorByTitle(group.name),
+				members: group.senateMembers
 			};
 		});
 	};

--- a/src/components/Assemblies/shared.ts
+++ b/src/components/Assemblies/shared.ts
@@ -1,3 +1,4 @@
+import type { AssemblyMember } from '$lib/datasheets/assembly-member';
 import type { MemberGroup } from '../../routes/assemblies/[id]/+page.server';
 
 export interface PartySelected {
@@ -47,6 +48,7 @@ export interface PartySeat {
 	name: string;
 	color: string;
 	count: number;
+	members?: AssemblyMember[];
 }
 
 export interface CabinetSeat {
@@ -65,4 +67,11 @@ export const getSenateColorByTitle = (title: string) => {
 		default:
 			return '#A8A8A8';
 	}
+};
+
+export type TooltipProp = {
+	title: string;
+	additional: string;
+	x: number;
+	y: number;
 };

--- a/src/routes/assemblies/[id]/+page.server.ts
+++ b/src/routes/assemblies/[id]/+page.server.ts
@@ -38,6 +38,7 @@ export interface Summary {
 export interface MemberGroup {
 	name: string;
 	total: number;
+	senateMembers?: AssemblyMember[];
 	parties?: (Pick<Party, 'name' | 'color'> & { count: number; members?: AssemblyMember[] })[];
 }
 
@@ -93,6 +94,7 @@ export async function load({ params }) {
 						total: group.subgroups.reduce((sum, subGroup) => sum + subGroup.members.length, 0)
 					}
 				: {
+						senateMembers: group.members,
 						total: group.members.length
 					})
 		}));


### PR DESCRIPTION
# Issue ticket number and link

close #116 

## What have been done

- Add tooltips for Assembly, Parliament and Senate members
- Adjust some type to include members list data

## Screenshot (if any)


<img width="409" alt="Screenshot 2567-10-16 at 22 23 13" src="https://github.com/user-attachments/assets/22e7b6a3-796b-41e1-82c8-555b18112fdd">
<img width="472" alt="Screenshot 2567-10-16 at 22 23 27" src="https://github.com/user-attachments/assets/058d0316-2cda-4c76-a4b0-2ba1fd237fc5">
<img width="435" alt="Screenshot 2567-10-16 at 22 23 37" src="https://github.com/user-attachments/assets/20e798bc-23ce-4f9a-9e12-f0783912b302">
