### PR TITLE
fix: tooltip partially missing in small screen

### DIFF
--- a/src/components/Assemblies/AssemblyTooltip.svelte
+++ b/src/components/Assemblies/AssemblyTooltip.svelte
@@ -1,11 +1,33 @@
 <script lang="ts">
+	import { afterUpdate } from 'svelte';
 	import type { TooltipProp } from './shared';
 
 	export let tooltipProp: TooltipProp | null = null;
+	let tooltipRef: HTMLDivElement;
+	let innerWidth: number;
+
+	afterUpdate(() => {
+		if (!tooltipProp) return;
+
+		const tooltip = tooltipRef.getBoundingClientRect();
+		const { width } = tooltip;
+
+		tooltipProp.x -= width / 2;
+
+		// adjust tooltip position when its size exceed window
+		if (innerWidth < tooltipProp.x + width) {
+			tooltipProp.x = innerWidth - width;
+		} else if (tooltipProp.x < 0) {
+			tooltipProp.x = 0;
+		}
+	});
 </script>
+
+<svelte:window bind:innerWidth />
 
 {#if tooltipProp}
 	<div
+		bind:this={tooltipRef}
 		style:left="{tooltipProp.x}px"
 		style:top="{tooltipProp.y}px"
 		class="label-01 absolute z-10 flex min-w-max flex-col


### PR DESCRIPTION
# Related GitHub issues


## What have been done

- Center tooltip's position
- Check screen boundary and adjust tooltip's position to display within screen

## Screenshot (if any)

<img width="486" alt="Screenshot 2567-10-22 at 01 29 45" src="https://github.com/user-attachments/assets/ddf4c736-f8c1-4bf6-8b50-7b005b468227">

