### PR TITLE
fix: migrate away from cloudflare-pages action as it is deprecated

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -54,11 +54,8 @@ jobs:
         with:
           name: ${{ env.ARTIFACT }}
       - name: Publish to Cloudflare Pages
-        uses: cloudflare/pages-action@v1
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: parliament-watch
-          directory: ./
-          branch: ${{ github.ref_name }}
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          command: pages deploy ./ --project-name=parliament-watch --branch=${{ github.ref_name }}


### PR DESCRIPTION
# Related GitHub issues

Close #141 

## What have been done

- Changed the `deploy-to-staging` step in `.github/workflows/staging.yml` to use `cloudflare/wrangler-action@v3` instead of   the deprecated `cloudflare/pages-action@v1`

_**Note:** With this change, we will lose the [deployments records](https://github.com/wevisdemo/parliament-watch/deployments) as it is not yet supported by this wrangler action. (It is mentioned in the wrangler's [repo README](https://github.com/cloudflare/pages-action?tab=readme-ov-file) and this [issue](https://github.com/cloudflare/wrangler-action/issues/301))_

## Screenshot (if any)
_N/A_

## Help needed (if any)

- Could you temporarily set the [staging workflow](https://github.com/wevisdemo/parliament-watch/actions/workflows/staging.yml) to run on this branch? As I cannot test it on my forked repo because it requires secrets
