### PR TITLE
fix: update SectionMenuItem on mobile

### DIFF
--- a/src/components/Index/SectionMenuItem.svelte
+++ b/src/components/Index/SectionMenuItem.svelte
@@ -8,10 +8,10 @@
 	export let icon: ComponentType;
 </script>
 
-<li class="flex flex-1">
+<li class="flex w-full flex-1">
 	<a
 		{href}
-		class="body-01 flex items-start gap-3 bg-white p-4 text-[color:inherit] !no-underline hover:bg-ui-01 md:flex-col md:items-center md:gap-1 md:p-8 md:text-center"
+		class="body-01 flex w-full items-start gap-3 bg-white p-4 text-[color:inherit] !no-underline hover:bg-ui-01 md:flex-col md:items-center md:gap-1 md:p-8 md:text-center"
 	>
 		<svelte:component this={icon} class="aspect-square h-auto w-6 md:w-8" />
 		<span class="flex flex-1 flex-col gap-1">


### PR DESCRIPTION
## What have been done

I noticed that the arrow in the section menu items was misaligned on mobile or small screens.
So, I added a `width: 100%` style, `w-full` to push the arrows to the right side of the screen, ensuring proper alignment.

## Screenshot (if any)
* Before
<img width="385" alt="Screenshot 2568-01-19 at 23 10 08" src="https://github.com/user-attachments/assets/63fcc8fb-dea6-4d36-a95c-b2a852f4425b" />

* After
<img width="387" alt="Screenshot 2568-01-19 at 23 10 25" src="https://github.com/user-attachments/assets/5c6b0323-307a-436b-b25e-43ee5e11d1f4" />

---

If you have any feedback or suggestions, please let me know.
