### PR TITLE
fix: bills explore table styles

### DIFF
--- a/src/routes/bills/explore/+page.svelte
+++ b/src/routes/bills/explore/+page.svelte
@@ -180,7 +180,7 @@
 	</div>
 	<svelte:fragment slot="table" let:cellKey let:cellValue>
 		{#if cellKey === 'proposedOn'}
-			<div class="body-compact-01 w-20 text-gray-60">
+			<div class="body-compact-01 whitespace-nowrap text-gray-60">
 				{new Date(cellValue).toLocaleString('th-TH', {
 					day: 'numeric',
 					month: 'short',

--- a/src/routes/bills/explore/+page.svelte
+++ b/src/routes/bills/explore/+page.svelte
@@ -192,7 +192,7 @@
 				>{cellValue.title}</a
 			>
 		{:else if cellKey === 'status'}
-			<BillStatusTag status={cellValue} isLarge />
+			<BillStatusTag class="m-0" status={cellValue} isLarge />
 		{:else if cellValue}
 			<a href={cellValue.url} title={cellValue.label} target="_blank" rel="noopener noreferrer">
 				<DocumentPdf />

--- a/src/routes/bills/explore/+page.svelte
+++ b/src/routes/bills/explore/+page.svelte
@@ -180,13 +180,13 @@
 	</div>
 	<svelte:fragment slot="table" let:cellKey let:cellValue>
 		{#if cellKey === 'proposedOn'}
-			<span class="body-compact-01 text-gray-60"
-				>{new Date(cellValue).toLocaleString('th-TH', {
+			<div class="body-compact-01 w-20 text-gray-60">
+				{new Date(cellValue).toLocaleString('th-TH', {
 					day: 'numeric',
 					month: 'short',
 					year: '2-digit'
-				})}</span
-			>
+				})}
+			</div>
 		{:else if cellKey === 'titleColumn'}
 			<a class="text-text-01 underline hover:text-interactive-01" href="/bills/{cellValue.id}"
 				>{cellValue.title}</a


### PR DESCRIPTION
## What have been done
I updated the width of the `proposedOn` cell in the Bills Explore page to ensure the text stays on one line for small screen. Additionally, I removed the margin from the `BillStatusTag` to align it with the content.

## Screenshot (if any)
* Before
<img width="389" alt="Screenshot 2568-01-23 at 23 10 58" src="https://github.com/user-attachments/assets/cacee358-5118-4e7f-91f4-2c144708d0c2" />

* After
<img width="385" alt="Screenshot 2568-01-23 at 23 10 40" src="https://github.com/user-attachments/assets/76cbcbe0-b9ed-491c-bb08-457930efdf8d" />

---

If you have any feedback or suggestions, please let me know.

