### PR TITLE
Refactor <Proposer> by pulling out model imports

### DIFF
--- a/src/components/BillCard/BillCard.svelte
+++ b/src/components/BillCard/BillCard.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import { ArrowRight } from 'carbon-icons-svelte';
 	import BillStatusTag from '$components/BillStatusTag/BillStatusTag.svelte';
-	import { type Bill } from '$models/bill';
+	import { BillProposerType, type Bill } from '$models/bill';
 	import { twMerge } from 'tailwind-merge';
 	import Proposer from '$components/Proposer/Proposer.svelte';
+	import { getRoleHistoryAtTime } from '$models/politician';
+	import { AssemblyName } from '$models/assembly';
 
 	export let bill: Bill;
 	export let orientation: 'landscape' | 'portrait' = 'landscape';
@@ -32,7 +34,30 @@
 		</a>
 		<p class="text-sm text-text-02"><span class="mr-1 font-bold">ชื่อทางการ</span>{bill.title}</p>
 		<p class="font-semibold">เสนอโดย</p>
-		<Proposer {bill} />
+		<Proposer
+			politician={bill.proposerType === BillProposerType.Politician && bill.proposedLedByPolitician
+				? {
+						...bill.proposedLedByPolitician,
+						assembly: getRoleHistoryAtTime(
+							bill.proposedLedByPolitician.assemblyRoles,
+							bill.proposedOn
+						)?.assembly,
+						partyName: getRoleHistoryAtTime(
+							bill.proposedLedByPolitician.partyRoles,
+							bill.proposedOn
+						)?.party.name
+					}
+				: undefined}
+			assembly={bill.proposerType === BillProposerType.Assembly && bill.proposedByAssembly
+				? {
+						...bill.proposedByAssembly,
+						isCabinet: bill.proposedByAssembly.name === AssemblyName.Cabinet
+					}
+				: undefined}
+			people={bill.proposerType === BillProposerType.People && bill.proposedByPeople
+				? bill.proposedByPeople
+				: undefined}
+		/>
 	</div>
 
 	<div

--- a/src/components/BillCard/BillCard.svelte
+++ b/src/components/BillCard/BillCard.svelte
@@ -3,9 +3,14 @@
 	import BillStatusTag from '$components/BillStatusTag/BillStatusTag.svelte';
 	import { BillProposerType, type Bill } from '$models/bill';
 	import { twMerge } from 'tailwind-merge';
-	import Proposer from '$components/Proposer/Proposer.svelte';
+	import Proposer, {
+		type AssemblyProposer,
+		type PeopleProposer,
+		type PoliticianProposer
+	} from '$components/Proposer/Proposer.svelte';
 	import { getRoleHistoryAtTime } from '$models/politician';
 	import { AssemblyName } from '$models/assembly';
+	import { getProposerFromBill } from '$lib/model-component-adapters/bill-proposer';
 
 	export let bill: Bill;
 	export let orientation: 'landscape' | 'portrait' = 'landscape';
@@ -34,30 +39,7 @@
 		</a>
 		<p class="text-sm text-text-02"><span class="mr-1 font-bold">ชื่อทางการ</span>{bill.title}</p>
 		<p class="font-semibold">เสนอโดย</p>
-		<Proposer
-			politician={bill.proposerType === BillProposerType.Politician && bill.proposedLedByPolitician
-				? {
-						...bill.proposedLedByPolitician,
-						assembly: getRoleHistoryAtTime(
-							bill.proposedLedByPolitician.assemblyRoles,
-							bill.proposedOn
-						)?.assembly,
-						partyName: getRoleHistoryAtTime(
-							bill.proposedLedByPolitician.partyRoles,
-							bill.proposedOn
-						)?.party.name
-					}
-				: undefined}
-			assembly={bill.proposerType === BillProposerType.Assembly && bill.proposedByAssembly
-				? {
-						...bill.proposedByAssembly,
-						isCabinet: bill.proposedByAssembly.name === AssemblyName.Cabinet
-					}
-				: undefined}
-			people={bill.proposerType === BillProposerType.People && bill.proposedByPeople
-				? bill.proposedByPeople
-				: undefined}
-		/>
+		<Proposer proposer={getProposerFromBill(bill)} />
 	</div>
 
 	<div

--- a/src/components/BillCard/BillCard.svelte
+++ b/src/components/BillCard/BillCard.svelte
@@ -1,15 +1,9 @@
 <script lang="ts">
 	import { ArrowRight } from 'carbon-icons-svelte';
 	import BillStatusTag from '$components/BillStatusTag/BillStatusTag.svelte';
-	import { BillProposerType, type Bill } from '$models/bill';
+	import type { Bill } from '$models/bill';
 	import { twMerge } from 'tailwind-merge';
-	import Proposer, {
-		type AssemblyProposer,
-		type PeopleProposer,
-		type PoliticianProposer
-	} from '$components/Proposer/Proposer.svelte';
-	import { getRoleHistoryAtTime } from '$models/politician';
-	import { AssemblyName } from '$models/assembly';
+	import Proposer from '$components/Proposer/Proposer.svelte';
 	import { getProposerFromBill } from '$lib/model-component-adapters/bill-proposer';
 
 	export let bill: Bill;

--- a/src/components/Proposer/Proposer.story.svelte
+++ b/src/components/Proposer/Proposer.story.svelte
@@ -23,7 +23,7 @@
 	<Hst.Variant title="Politician">
 		<Proposer
 			{orientation}
-			politician={{
+			proposer={{
 				id: movingForwardPolitician.id,
 				firstname: movingForwardPolitician.firstname,
 				lastname: movingForwardPolitician.lastname,
@@ -41,7 +41,7 @@
 	<Hst.Variant title="Cabinet">
 		<Proposer
 			{orientation}
-			assembly={{
+			proposer={{
 				id: 'คณะรัฐมนตรี-64',
 				isCabinet: true,
 				abbreviation: 'คณะรัฐมนตรี',
@@ -53,7 +53,7 @@
 	<Hst.Variant title="Representatives">
 		<Proposer
 			{orientation}
-			assembly={{
+			proposer={{
 				id: rep26.id,
 				isCabinet: false,
 				abbreviation: rep26.name,
@@ -65,12 +65,13 @@
 	<Hst.Variant title="People">
 		<Proposer
 			{orientation}
-			people={{
+			proposer={{
 				ledBy: 'นายยิ่งชีพ',
 				signatoryCount: 150000
 			}}
 		/>
 	</Hst.Variant>
+
 	<Hst.Variant title="Not Found">
 		<Proposer {orientation} />
 	</Hst.Variant>

--- a/src/components/Proposer/Proposer.story.svelte
+++ b/src/components/Proposer/Proposer.story.svelte
@@ -1,18 +1,7 @@
 <script lang="ts">
 	import type { Hst } from '@histoire/plugin-svelte';
 	import Proposer from './Proposer.svelte';
-	import { AssemblyName } from '$models/assembly';
 	import type { ComponentProps } from 'svelte';
-	import { movingForwardPolitician } from '../../mocks/data/politician';
-	import { movingForwardParty } from '../../mocks/data/party';
-
-	const rep26 = {
-		id: 'สภาผู้แทนราษฎร-26',
-		name: AssemblyName.Representatives,
-		abbreviation: 'สส.',
-		term: 26,
-		startedAt: new Date('01/01/2023')
-	};
 
 	let orientation: ComponentProps<Proposer>['orientation'] = 'landscape';
 
@@ -24,17 +13,17 @@
 		<Proposer
 			{orientation}
 			proposer={{
-				id: movingForwardPolitician.id,
-				firstname: movingForwardPolitician.firstname,
-				lastname: movingForwardPolitician.lastname,
-				avatar: movingForwardPolitician.avatar,
+				id: 'พริษฐ์-วัชรสินธุ',
+				firstname: 'พริษฐ์',
+				lastname: 'วัชรสินธุ',
+				avatar: 'https://via.placeholder.com/64',
 				assembly: {
-					id: rep26.id,
-					abbreviation: rep26.abbreviation,
-					term: rep26.term,
-					startedAt: rep26.startedAt
+					id: 'สภาผู้แทนราษฎร-26',
+					abbreviation: 'ส.ส.',
+					term: 26,
+					startedAt: new Date('01/01/2023')
 				},
-				partyName: movingForwardParty.name
+				partyName: 'ก้าวไกล'
 			}}
 		/>
 	</Hst.Variant>
@@ -54,11 +43,11 @@
 		<Proposer
 			{orientation}
 			proposer={{
-				id: rep26.id,
+				id: 'สภาผู้แทนราษฎร-26',
 				isCabinet: false,
-				abbreviation: rep26.name,
-				term: rep26.term,
-				startedAt: rep26.startedAt
+				abbreviation: 'ส.ส.',
+				term: 26,
+				startedAt: new Date('01/01/2023')
 			}}
 		/>
 	</Hst.Variant>

--- a/src/components/Proposer/Proposer.story.svelte
+++ b/src/components/Proposer/Proposer.story.svelte
@@ -30,7 +30,7 @@
 				avatar: movingForwardPolitician.avatar,
 				assembly: {
 					id: rep26.id,
-					name: rep26.abbreviation,
+					abbreviation: rep26.abbreviation,
 					term: rep26.term,
 					startedAt: rep26.startedAt
 				},
@@ -44,7 +44,7 @@
 			assembly={{
 				id: 'คณะรัฐมนตรี-64',
 				isCabinet: true,
-				name: 'คณะรัฐมนตรี',
+				abbreviation: 'คณะรัฐมนตรี',
 				term: 64,
 				startedAt: new Date('04/09/2024')
 			}}
@@ -56,7 +56,7 @@
 			assembly={{
 				id: rep26.id,
 				isCabinet: false,
-				name: rep26.name,
+				abbreviation: rep26.name,
 				term: rep26.term,
 				startedAt: rep26.startedAt
 			}}

--- a/src/components/Proposer/Proposer.story.svelte
+++ b/src/components/Proposer/Proposer.story.svelte
@@ -1,28 +1,17 @@
 <script lang="ts">
 	import type { Hst } from '@histoire/plugin-svelte';
 	import Proposer from './Proposer.svelte';
-	import { AssemblyName, type Assembly } from '$models/assembly';
-	import { BillProposerType } from '$models/bill';
-	import { inProgressBill } from '../../mocks/data/bill';
+	import { AssemblyName } from '$models/assembly';
 	import type { ComponentProps } from 'svelte';
+	import { movingForwardPolitician } from '../../mocks/data/politician';
+	import { movingForwardParty } from '../../mocks/data/party';
 
-	const rep26: Assembly = {
+	const rep26 = {
 		id: 'สภาผู้แทนราษฎร-26',
 		name: AssemblyName.Representatives,
 		abbreviation: 'สส.',
 		term: 26,
-		startedAt: new Date('01/01/2023'),
-		origin:
-			'มาจากการเลือกตั้งทั่วไป พ.ศ. 2566 ประกอบด้วยสมาชิก (สส.) 500 คน ตามระบบจัดสรรปันส่วนผสมโดย 400 คนเป็นผู้แทนเขต และอีก 100 คน มาจากระบบบัญชีรายชื่อ',
-		mainRoles: [
-			'ประธานสภา',
-			'รองประธานสภา คนที่ 1',
-			'รองประธานสภา คนที่ 2',
-			'ประธานฝ่ายรัฐบาล',
-			'ประธานฝ่ายค้าน'
-		],
-		governmentParties: [],
-		oppositionParties: []
+		startedAt: new Date('01/01/2023')
 	};
 
 	let orientation: ComponentProps<Proposer>['orientation'] = 'landscape';
@@ -32,32 +21,58 @@
 
 <Hst.Story title="Proposer" layout={{ type: 'grid', width: 400 }}>
 	<Hst.Variant title="Politician">
-		<Proposer {orientation} bill={inProgressBill} />
+		<Proposer
+			{orientation}
+			politician={{
+				id: movingForwardPolitician.id,
+				firstname: movingForwardPolitician.firstname,
+				lastname: movingForwardPolitician.lastname,
+				avatar: movingForwardPolitician.avatar,
+				assembly: {
+					id: rep26.id,
+					name: rep26.abbreviation,
+					term: rep26.term,
+					startedAt: rep26.startedAt
+				},
+				partyName: movingForwardParty.name
+			}}
+		/>
 	</Hst.Variant>
 	<Hst.Variant title="Cabinet">
 		<Proposer
 			{orientation}
-			bill={{
-				...inProgressBill,
-				proposerType: BillProposerType.Assembly,
-				proposedLedByPolitician: undefined,
-				proposedByAssembly: rep26
+			assembly={{
+				id: 'คณะรัฐมนตรี-64',
+				isCabinet: true,
+				name: 'คณะรัฐมนตรี',
+				term: 64,
+				startedAt: new Date('04/09/2024')
+			}}
+		/>
+	</Hst.Variant>
+	<Hst.Variant title="Representatives">
+		<Proposer
+			{orientation}
+			assembly={{
+				id: rep26.id,
+				isCabinet: false,
+				name: rep26.name,
+				term: rep26.term,
+				startedAt: rep26.startedAt
 			}}
 		/>
 	</Hst.Variant>
 	<Hst.Variant title="People">
 		<Proposer
 			{orientation}
-			bill={{
-				...inProgressBill,
-				proposerType: BillProposerType.People,
-				proposedLedByPolitician: undefined,
-				proposedByPeople: {
-					ledBy: 'นายยิ่งชีพ',
-					signatoryCount: 150000
-				}
+			people={{
+				ledBy: 'นายยิ่งชีพ',
+				signatoryCount: 150000
 			}}
 		/>
+	</Hst.Variant>
+	<Hst.Variant title="Not Found">
+		<Proposer {orientation} />
 	</Hst.Variant>
 
 	<svelte:fragment slot="controls">

--- a/src/components/Proposer/Proposer.svelte
+++ b/src/components/Proposer/Proposer.svelte
@@ -6,7 +6,7 @@
 		avatar: string;
 		assembly?: {
 			id: string;
-			name: string;
+			abbreviation: string;
 			term: number;
 			startedAt: Date;
 		};
@@ -16,7 +16,7 @@
 	export type AssemblyProposer = {
 		id: string;
 		isCabinet: boolean;
-		name: string;
+		abbreviation: string;
 		term: number;
 		startedAt: Date;
 	};
@@ -65,7 +65,7 @@
 				</a>
 				{#if assembly}
 					<a href={`/assemblies/${assembly.id}`} class="text-sm text-black underline">
-						{assembly.name} ชุดที่ {assembly.term} ({getBudistYear(assembly.startedAt)})
+						{assembly.abbreviation} ชุดที่ {assembly.term} ({getBudistYear(assembly.startedAt)})
 					</a>
 				{/if}
 			</p>
@@ -74,7 +74,7 @@
 			{/if}
 		</div>
 	{:else if assembly}
-		{@const { id, name, term, isCabinet, startedAt } = assembly}
+		{@const { id, abbreviation, term, isCabinet, startedAt } = assembly}
 		<div class="flex h-6 w-6 items-center justify-center rounded-full bg-black">
 			<svelte:component
 				this={isCabinet ? GeneralIcon : PoliticianIcon}
@@ -83,7 +83,7 @@
 			/>
 		</div>
 		<a href={`/assemblies/${id}`} class="text-sm text-black">
-			{name}
+			{abbreviation}
 			<span class="underline">ชุดที่ {term} ({getBudistYear(startedAt)})</span>
 		</a>
 	{:else if people}
@@ -95,7 +95,7 @@
 		<p class="text-sm text-black">
 			{ledBy}
 			{#if signatoryCount}
-				<span class="text-gray-60">และประชาชน {signatoryCount} คน</span>
+				<span class="text-gray-60">และประชาชน {signatoryCount.toLocaleString()} คน</span>
 			{/if}
 		</p>
 	{:else}

--- a/src/components/Proposer/Proposer.svelte
+++ b/src/components/Proposer/Proposer.svelte
@@ -1,9 +1,36 @@
+<script context="module" lang="ts">
+	export type PoliticianProposer = {
+		id: string;
+		firstname: string;
+		lastname: string;
+		avatar: string;
+		assembly?: {
+			id: string;
+			name: string;
+			term: number;
+			startedAt: Date;
+		};
+		partyName?: string;
+	};
+
+	export type AssemblyProposer = {
+		id: string;
+		isCabinet: boolean;
+		name: string;
+		term: number;
+		startedAt: Date;
+	};
+
+	export type PeopleProposer = {
+		ledBy: string;
+		signatoryCount: number;
+	};
+</script>
+
 <script lang="ts">
 	import GeneralIcon from '$components/icons/GeneralIcon.svelte';
 	import PeopleIcon from '$components/icons/PeopleIcon.svelte';
 	import PoliticianIcon from '$components/icons/PoliticianIcon.svelte';
-	import { AssemblyName } from '$models/assembly';
-	import type { Bill } from '$models/bill';
 	import dayjs from 'dayjs';
 	import 'dayjs/locale/th';
 	import buddhistEra from 'dayjs/plugin/buddhistEra';
@@ -11,7 +38,10 @@
 	dayjs.extend(buddhistEra);
 	dayjs.locale('th');
 
-	export let bill: Bill;
+	export let politician: PoliticianProposer | undefined = undefined;
+	export let assembly: AssemblyProposer | undefined = undefined;
+	export let people: PeopleProposer | undefined = undefined;
+
 	export let orientation: 'landscape' | 'portrait' = 'landscape';
 
 	$: isLandscape = orientation === 'landscape';
@@ -22,22 +52,8 @@
 </script>
 
 <div class="flex {isLandscape ? 'flex-col gap-x-2 md:flex-row' : 'flex-col'}">
-	{#if bill.proposedLedByPolitician}
-		{@const { id, firstname, lastname, avatar, assemblyRoles, partyRoles } =
-			bill.proposedLedByPolitician}
-
-		{@const matchedAssemblyRole = assemblyRoles.find(
-			({ startedAt, endedAt }) =>
-				bill.proposedOn.getTime() >= startedAt.getTime() &&
-				(!endedAt || bill.proposedOn.getTime() <= endedAt.getTime())
-		)}
-
-		{@const matchedPartyRoles = partyRoles.find(
-			({ startedAt, endedAt }) =>
-				bill.proposedOn.getTime() >= startedAt.getTime() &&
-				(!endedAt || bill.proposedOn.getTime() <= endedAt.getTime())
-		)}
-
+	{#if politician}
+		{@const { id, firstname, lastname, avatar, assembly, partyName } = politician}
 		<figure class="h-6 w-6 shrink-0 overflow-hidden rounded-full bg-gray-20">
 			<img src={avatar} alt="{firstname} {lastname}" class="h-full w-full" loading="lazy" />
 		</figure>
@@ -47,27 +63,18 @@
 					{firstname}
 					{lastname}
 				</a>
-				{#if matchedAssemblyRole}
-					{@const { assembly } = matchedAssemblyRole}
-					<!-- TODO: cabinet is not released yet -->
-					{@const isCabinet = assembly.name === AssemblyName.Cabinet}
-					<svelte:element
-						this={isCabinet ? 'p' : 'a'}
-						href={isCabinet ? undefined : `/assemblies/${assembly.id}`}
-						class="text-sm text-black {isCabinet ? '' : 'underline'}"
-					>
-						{assembly.abbreviation} ชุดที่ {assembly.term} ({getBudistYear(assembly.startedAt)})
-					</svelte:element>
+				{#if assembly}
+					<a href={`/assemblies/${assembly.id}`} class="text-sm text-black underline">
+						{assembly.name} ชุดที่ {assembly.term} ({getBudistYear(assembly.startedAt)})
+					</a>
 				{/if}
 			</p>
-			{#if matchedPartyRoles}
-				<span class="text-sm text-gray-60">พรรค{matchedPartyRoles.party.name}</span>
+			{#if partyName}
+				<span class="text-sm text-gray-60">พรรค{partyName}</span>
 			{/if}
 		</div>
-	{:else if bill.proposedByAssembly}
-		{@const { id, name, term, startedAt } = bill.proposedByAssembly}
-		<!-- TODO: cabinet is not released yet -->
-		{@const isCabinet = name === AssemblyName.Cabinet}
+	{:else if assembly}
+		{@const { id, name, term, isCabinet, startedAt } = assembly}
 		<div class="flex h-6 w-6 items-center justify-center rounded-full bg-black">
 			<svelte:component
 				this={isCabinet ? GeneralIcon : PoliticianIcon}
@@ -75,16 +82,12 @@
 				size={16}
 			/>
 		</div>
-		<svelte:element
-			this={isCabinet ? 'p' : 'a'}
-			href={isCabinet ? undefined : `/assemblies/${id}`}
-			class="text-sm text-black"
-		>
+		<a href={`/assemblies/${id}`} class="text-sm text-black">
 			{name}
 			<span class="underline">ชุดที่ {term} ({getBudistYear(startedAt)})</span>
-		</svelte:element>
-	{:else if bill.proposedByPeople}
-		{@const { ledBy, signatoryCount } = bill.proposedByPeople}
+		</a>
+	{:else if people}
+		{@const { ledBy, signatoryCount } = people}
 
 		<div class="flex h-6 w-6 items-center justify-center rounded-full bg-black">
 			<PeopleIcon class="stroke-white" size={16} />

--- a/src/components/Proposer/Proposer.svelte
+++ b/src/components/Proposer/Proposer.svelte
@@ -64,7 +64,7 @@
 					{lastname}
 				</a>
 				{#if assembly}
-					<a href={`/assemblies/${assembly.id}`} class="text-sm text-black underline">
+					<a href="/assemblies/{assembly.id}" class="text-sm text-black underline">
 						{assembly.abbreviation} ชุดที่ {assembly.term} ({getBudistYear(assembly.startedAt)})
 					</a>
 				{/if}
@@ -82,7 +82,7 @@
 				size={16}
 			/>
 		</div>
-		<a href={`/assemblies/${id}`} class="text-sm text-black">
+		<a href="/assemblies/{id}" class="text-sm text-black">
 			{abbreviation}
 			<span class="underline">ชุดที่ {term} ({getBudistYear(startedAt)})</span>
 		</a>

--- a/src/components/Proposer/Proposer.svelte
+++ b/src/components/Proposer/Proposer.svelte
@@ -38,10 +38,8 @@
 	dayjs.extend(buddhistEra);
 	dayjs.locale('th');
 
-	export let politician: PoliticianProposer | undefined = undefined;
-	export let assembly: AssemblyProposer | undefined = undefined;
-	export let people: PeopleProposer | undefined = undefined;
-
+	export let proposer: PoliticianProposer | AssemblyProposer | PeopleProposer | undefined =
+		undefined;
 	export let orientation: 'landscape' | 'portrait' = 'landscape';
 
 	$: isLandscape = orientation === 'landscape';
@@ -52,8 +50,10 @@
 </script>
 
 <div class="flex {isLandscape ? 'flex-col gap-x-2 md:flex-row' : 'flex-col'}">
-	{#if politician}
-		{@const { id, firstname, lastname, avatar, assembly, partyName } = politician}
+	{#if proposer === undefined}
+		<p class="text-sm text-gray-60">ไม่พบข้อมูล</p>
+	{:else if 'firstname' in proposer}
+		{@const { id, firstname, lastname, avatar, assembly, partyName } = proposer}
 		<figure class="h-6 w-6 shrink-0 overflow-hidden rounded-full bg-gray-20">
 			<img src={avatar} alt="{firstname} {lastname}" class="h-full w-full" loading="lazy" />
 		</figure>
@@ -73,8 +73,8 @@
 				<span class="text-sm text-gray-60">พรรค{partyName}</span>
 			{/if}
 		</div>
-	{:else if assembly}
-		{@const { id, abbreviation, term, isCabinet, startedAt } = assembly}
+	{:else if 'term' in proposer}
+		{@const { id, abbreviation, term, isCabinet, startedAt } = proposer}
 		<div class="flex h-6 w-6 items-center justify-center rounded-full bg-black">
 			<svelte:component
 				this={isCabinet ? GeneralIcon : PoliticianIcon}
@@ -86,9 +86,8 @@
 			{abbreviation}
 			<span class="underline">ชุดที่ {term} ({getBudistYear(startedAt)})</span>
 		</a>
-	{:else if people}
-		{@const { ledBy, signatoryCount } = people}
-
+	{:else}
+		{@const { ledBy, signatoryCount } = proposer}
 		<div class="flex h-6 w-6 items-center justify-center rounded-full bg-black">
 			<PeopleIcon class="stroke-white" size={16} />
 		</div>
@@ -98,7 +97,5 @@
 				<span class="text-gray-60">และประชาชน {signatoryCount.toLocaleString()} คน</span>
 			{/if}
 		</p>
-	{:else}
-		<p class="text-sm text-gray-60">ไม่พบข้อมูล</p>
 	{/if}
 </div>

--- a/src/lib/model-component-adapters/bill-proposer.ts
+++ b/src/lib/model-component-adapters/bill-proposer.ts
@@ -1,0 +1,31 @@
+import type {
+	AssemblyProposer,
+	PeopleProposer,
+	PoliticianProposer
+} from '$components/Proposer/Proposer.svelte';
+import { AssemblyName } from '$models/assembly';
+import { type Bill } from '$models/bill';
+import { getRoleHistoryAtTime } from '$models/politician';
+
+export function getProposerFromBill(
+	bill: Bill
+): PoliticianProposer | AssemblyProposer | PeopleProposer | undefined {
+	if (bill.proposedLedByPolitician) {
+		return {
+			...bill.proposedLedByPolitician,
+			assembly: getRoleHistoryAtTime(bill.proposedLedByPolitician.assemblyRoles, bill.proposedOn)
+				?.assembly,
+			partyName: getRoleHistoryAtTime(bill.proposedLedByPolitician.partyRoles, bill.proposedOn)
+				?.party.name
+		};
+	}
+
+	if (bill.proposedByAssembly) {
+		return {
+			...bill.proposedByAssembly,
+			isCabinet: bill.proposedByAssembly.name === AssemblyName.Cabinet
+		};
+	}
+
+	return bill.proposedByPeople;
+}

--- a/src/models/politician.ts
+++ b/src/models/politician.ts
@@ -37,3 +37,19 @@ export type PartyRoleHistory = {
 	startedAt: Date;
 	endedAt?: Date;
 };
+
+export type RoleHistory = {
+	role: string;
+	startedAt: Date;
+	endedAt?: Date;
+};
+
+export function getRoleHistoryAtTime<T extends RoleHistory>(
+	histories: T[],
+	time: Date
+): T | undefined {
+	return histories.find(
+		({ startedAt, endedAt }) =>
+			time.getTime() >= startedAt.getTime() && (!endedAt || time.getTime() <= endedAt.getTime())
+	);
+}

--- a/src/routes/bills/[id]/+page.svelte
+++ b/src/routes/bills/[id]/+page.svelte
@@ -14,12 +14,12 @@
 	import { showModalListCoProposer } from '$components/bills/store';
 	import ModalListCoProposers from '$components/bills/ModalListCoProposers.svelte';
 	import CoProposer from '$components/bills/CoProposer.svelte';
-	import { getRoleHistoryAtTime, type Politician } from '$models/politician.js';
+	import type { Politician } from '$models/politician.js';
 	import CoPartyProposer from '$components/bills/CoPartyProposer.svelte';
 	import Progress from '$components/bills/Progress.svelte';
 	import type { Party } from '$models/party.js';
 	import DataPeriodRemark from '$components/DataPeriodRemark/DataPeriodRemark.svelte';
-	import { AssemblyName } from '$models/assembly.js';
+	import { getProposerFromBill } from '$lib/model-component-adapters/bill-proposer';
 
 	const NO_PARTY_FOUND_LABEL = 'ไม่พบข้อมูลพรรค';
 
@@ -133,31 +133,7 @@
 					</div>
 					<div>
 						<b>เสนอโดย</b>
-						<Proposer
-							politician={bill.proposerType === BillProposerType.Politician &&
-							bill.proposedLedByPolitician
-								? {
-										...bill.proposedLedByPolitician,
-										assembly: getRoleHistoryAtTime(
-											bill.proposedLedByPolitician.assemblyRoles,
-											bill.proposedOn
-										)?.assembly,
-										partyName: getRoleHistoryAtTime(
-											bill.proposedLedByPolitician.partyRoles,
-											bill.proposedOn
-										)?.party.name
-									}
-								: undefined}
-							assembly={bill.proposerType === BillProposerType.Assembly && bill.proposedByAssembly
-								? {
-										...bill.proposedByAssembly,
-										isCabinet: bill.proposedByAssembly.name === AssemblyName.Cabinet
-									}
-								: undefined}
-							people={bill.proposerType === BillProposerType.People && bill.proposedByPeople
-								? bill.proposedByPeople
-								: undefined}
-						/>
+						<Proposer proposer={getProposerFromBill(bill)} />
 					</div>
 				</div>
 				<hr class="border-gray-30" />

--- a/src/routes/bills/[id]/+page.svelte
+++ b/src/routes/bills/[id]/+page.svelte
@@ -14,11 +14,12 @@
 	import { showModalListCoProposer } from '$components/bills/store';
 	import ModalListCoProposers from '$components/bills/ModalListCoProposers.svelte';
 	import CoProposer from '$components/bills/CoProposer.svelte';
-	import type { Politician } from '$models/politician.js';
+	import { getRoleHistoryAtTime, type Politician } from '$models/politician.js';
 	import CoPartyProposer from '$components/bills/CoPartyProposer.svelte';
 	import Progress from '$components/bills/Progress.svelte';
 	import type { Party } from '$models/party.js';
 	import DataPeriodRemark from '$components/DataPeriodRemark/DataPeriodRemark.svelte';
+	import { AssemblyName } from '$models/assembly.js';
 
 	const NO_PARTY_FOUND_LABEL = 'ไม่พบข้อมูลพรรค';
 
@@ -132,7 +133,31 @@
 					</div>
 					<div>
 						<b>เสนอโดย</b>
-						<Proposer {bill} />
+						<Proposer
+							politician={bill.proposerType === BillProposerType.Politician &&
+							bill.proposedLedByPolitician
+								? {
+										...bill.proposedLedByPolitician,
+										assembly: getRoleHistoryAtTime(
+											bill.proposedLedByPolitician.assemblyRoles,
+											bill.proposedOn
+										)?.assembly,
+										partyName: getRoleHistoryAtTime(
+											bill.proposedLedByPolitician.partyRoles,
+											bill.proposedOn
+										)?.party.name
+									}
+								: undefined}
+							assembly={bill.proposerType === BillProposerType.Assembly && bill.proposedByAssembly
+								? {
+										...bill.proposedByAssembly,
+										isCabinet: bill.proposedByAssembly.name === AssemblyName.Cabinet
+									}
+								: undefined}
+							people={bill.proposerType === BillProposerType.People && bill.proposedByPeople
+								? bill.proposedByPeople
+								: undefined}
+						/>
 					</div>
 				</div>
 				<hr class="border-gray-30" />


### PR DESCRIPTION
# Related GitHub issues

Close #167 

## What have been done

- Define models used in this share component
- Pull out assembly role lookup at specific time to Politician model
- Add two more variants in story
- Export prop types for future usages

## Screenshot (if any)

<img width="878" alt="Screenshot 2025-02-21 at 8 49 03 PM" src="https://github.com/user-attachments/assets/c570151f-f70e-4983-87f8-398d723fb5ec" />

## Help needed (if any)

- Feedback on the BIG politician prop.
- Should I introduce an interim function as an adapter from `Bill` to the component's props? Since this will be bubble up in `<BillCard>` too.
