### PR TITLE
refactor: Decouple models from PromiseList and PromiseCard

### DIFF
--- a/src/components/PromiseList/PromiseCard.story.svelte
+++ b/src/components/PromiseList/PromiseCard.story.svelte
@@ -41,10 +41,10 @@
 
 <Hst.Story title="PromiseCard">
 	<Hst.Variant title="PromiseCard.notList">
-		<PromiseCard {...promiseSummary} isList={false} />
+		<PromiseCard {...promiseSummary} />
 	</Hst.Variant>
 	<Hst.Variant title="PromiseCard.isList">
-		<PromiseCard {...promiseSummary} isList={true} />
+		<PromiseCard {...promiseSummary} isList />
 	</Hst.Variant>
 
 	<svelte:fragment slot="controls">

--- a/src/components/PromiseList/PromiseCard.story.svelte
+++ b/src/components/PromiseList/PromiseCard.story.svelte
@@ -41,10 +41,28 @@
 
 <Hst.Story title="PromiseCard">
 	<Hst.Variant title="PromiseCard.notList">
-		<PromiseCard {promiseSummary} isList={false} />
+		<PromiseCard
+			id={promiseSummary.id}
+			status={promiseSummary.status}
+			latestProgressDate={promiseSummary.latestProgressDate}
+			party={promiseSummary.party}
+			statements={promiseSummary.statements}
+			keywords={promiseSummary.keywords}
+			categories={promiseSummary.categories}
+			isList={false}
+		/>
 	</Hst.Variant>
 	<Hst.Variant title="PromiseCard.isList">
-		<PromiseCard {promiseSummary} isList={true} />
+		<PromiseCard
+			id={promiseSummary.id}
+			status={promiseSummary.status}
+			latestProgressDate={promiseSummary.latestProgressDate}
+			party={promiseSummary.party}
+			statements={promiseSummary.statements}
+			keywords={promiseSummary.keywords}
+			categories={promiseSummary.categories}
+			isList={true}
+		/>
 	</Hst.Variant>
 
 	<svelte:fragment slot="controls">

--- a/src/components/PromiseList/PromiseCard.story.svelte
+++ b/src/components/PromiseList/PromiseCard.story.svelte
@@ -41,28 +41,10 @@
 
 <Hst.Story title="PromiseCard">
 	<Hst.Variant title="PromiseCard.notList">
-		<PromiseCard
-			id={promiseSummary.id}
-			status={promiseSummary.status}
-			latestProgressDate={promiseSummary.latestProgressDate}
-			party={promiseSummary.party}
-			statements={promiseSummary.statements}
-			keywords={promiseSummary.keywords}
-			categories={promiseSummary.categories}
-			isList={false}
-		/>
+		<PromiseCard {...promiseSummary} isList={false} />
 	</Hst.Variant>
 	<Hst.Variant title="PromiseCard.isList">
-		<PromiseCard
-			id={promiseSummary.id}
-			status={promiseSummary.status}
-			latestProgressDate={promiseSummary.latestProgressDate}
-			party={promiseSummary.party}
-			statements={promiseSummary.statements}
-			keywords={promiseSummary.keywords}
-			categories={promiseSummary.categories}
-			isList={true}
-		/>
+		<PromiseCard {...promiseSummary} isList={true} />
 	</Hst.Variant>
 
 	<svelte:fragment slot="controls">

--- a/src/components/PromiseList/PromiseCard.svelte
+++ b/src/components/PromiseList/PromiseCard.svelte
@@ -11,7 +11,7 @@
 	export let keywords: string[];
 	export let categories: string[];
 
-	export let isList: boolean;
+	export let isList = false;
 
 	$: style = (() => {
 		switch (status) {

--- a/src/components/PromiseList/PromiseCard.svelte
+++ b/src/components/PromiseList/PromiseCard.svelte
@@ -3,21 +3,18 @@
 	import Quotes from 'carbon-icons-svelte/lib/Quotes.svelte';
 	import { PromiseStatus } from '$models/promise';
 
-	type PromiseSummary = {
-		id: string;
-		status: PromiseStatus;
-		latestProgressDate?: Date;
-		party: { name: string; logo: string };
-		statements: string[];
-		keywords: string[];
-		categories: string[];
-	};
+	export let id: string;
+	export let status: PromiseStatus;
+	export let latestProgressDate: Date | undefined = undefined;
+	export let party: { name: string; logo: string };
+	export let statements: string[];
+	export let keywords: string[];
+	export let categories: string[];
 
-	export let promiseSummary: PromiseSummary;
 	export let isList: boolean;
 
 	$: style = (() => {
-		switch (promiseSummary.status) {
+		switch (status) {
 			case PromiseStatus.inProgress:
 				return {
 					tag: 'bg-yellow-20 text-black',
@@ -42,10 +39,7 @@
 	})();
 </script>
 
-<a
-	href="/promises/{promiseSummary.id}"
-	class="{isList ? 'flex-row' : 'flex-col'} flex h-full w-full"
->
+<a href="/promises/{id}" class="{isList ? 'flex-row' : 'flex-col'} flex h-full w-full">
 	<div class="{isList ? 'w-1' : 'h-1 w-full'} {style.tag} shrink-0" />
 	<div
 		class="{isList
@@ -53,15 +47,11 @@
 			: 'flex flex-col'} group w-full shrink-0 cursor-pointer bg-ui-background duration-100 hover:bg-ui-03"
 	>
 		<div class="{isList ? 'col-span-3 flex-row gap-2' : 'flex-col px-6'} flex">
-			<a href="/promises/explore?party={promiseSummary.party.name}" class="shrink-0">
+			<a href="/promises/explore?party={party.name}" class="shrink-0">
 				<button class="flex items-center gap-2 {isList ? '' : 'py-4 '}">
-					<img
-						src={promiseSummary.party.logo}
-						alt=""
-						class="h-8 w-8 rounded-full border border-gray-30"
-					/>
+					<img src={party.logo} alt="" class="h-8 w-8 rounded-full border border-gray-30" />
 					{#if !isList}
-						<p class="body-01 text-text-01">พรรค{promiseSummary.party.name}</p>
+						<p class="body-01 text-text-01">พรรค{party.name}</p>
 					{/if}
 				</button>
 			</a>
@@ -80,7 +70,7 @@
 							? 'line-clamp-3 max-h-[calc(2.9*1.5em)]'
 							: 'line-clamp-[7] max-h-[calc(6.85*1.5em)]'} heading-compact-02 h-auto overflow-hidden leading-6"
 					>
-						{promiseSummary.statements}
+						{statements}
 					</p>
 				</div>
 				{#if !isList}
@@ -97,7 +87,7 @@
 		<div
 			class="{isList ? 'grid grid-cols-2' : 'flex flex-col px-6 pb-4 pt-3'} col-span-2 gap-[5px]"
 		>
-			{#each [{ label: 'คีย์เวิร์ด', items: promiseSummary.keywords }, { label: 'หมวด', items: promiseSummary.categories }] as { label, items } (label)}
+			{#each [{ label: 'คีย์เวิร์ด', items: keywords }, { label: 'หมวด', items: categories }] as { label, items } (label)}
 				<div class="{isList ? 'h-fit' : 'items-center'} flex flex-wrap gap-[2px]">
 					{#if !isList}
 						<p class="body-01 text-text-02">{label}</p>
@@ -132,7 +122,7 @@
 					<p class="heading-01">สถานะ</p>
 				{/if}
 				<div class="{style.tag} label-01 w-fit rounded-full px-2 py-[3px]">
-					{promiseSummary.status}
+					{status}
 				</div>
 			</div>
 			<div class="flex flex-col gap-1">
@@ -140,9 +130,7 @@
 					<p class="heading-01">อัปเดตล่าสุด</p>
 				{/if}
 				<div class="body-01">
-					{promiseSummary.latestProgressDate
-						? formatThaiDate(promiseSummary.latestProgressDate)
-						: '-'}
+					{latestProgressDate ? formatThaiDate(latestProgressDate) : '-'}
 				</div>
 			</div>
 		</div>

--- a/src/components/PromiseList/PromiseCard.svelte
+++ b/src/components/PromiseList/PromiseCard.svelte
@@ -1,7 +1,17 @@
 <script lang="ts">
 	import { formatThaiDate } from '$lib/date-parser';
-	import { PromiseStatus, type PromiseSummary } from '$models/promise';
 	import Quotes from 'carbon-icons-svelte/lib/Quotes.svelte';
+	import { PromiseStatus } from '$models/promise';
+
+	type PromiseSummary = {
+		id: string;
+		status: PromiseStatus;
+		latestProgressDate?: Date;
+		party: { name: string; logo: string };
+		statements: string[];
+		keywords: string[];
+		categories: string[];
+	};
 
 	export let promiseSummary: PromiseSummary;
 	export let isList: boolean;

--- a/src/components/PromiseList/PromiseList.svelte
+++ b/src/components/PromiseList/PromiseList.svelte
@@ -3,9 +3,9 @@
 	import PromiseCard from './PromiseCard.svelte';
 	import Grid from 'carbon-icons-svelte/lib/Grid.svelte';
 	import List from 'carbon-icons-svelte/lib/List.svelte';
-	import type { PromiseSummary } from '$models/promise';
+	import type { ComponentProps } from 'svelte';
 
-	export let summaries: PromiseSummary[];
+	export let summaries: ComponentProps<PromiseCard>['promiseSummary'][];
 
 	type SortByOptions = 'วันที่เคลื่อนไหวล่าสุด' | 'ตัวอักษร' | 'สถานะ';
 	let sortBy: SortByOptions = 'วันที่เคลื่อนไหวล่าสุด';

--- a/src/components/PromiseList/PromiseList.svelte
+++ b/src/components/PromiseList/PromiseList.svelte
@@ -5,7 +5,7 @@
 	import List from 'carbon-icons-svelte/lib/List.svelte';
 	import type { ComponentProps } from 'svelte';
 
-	export let summaries: ComponentProps<PromiseCard>['promiseSummary'][];
+	export let summaries: Omit<ComponentProps<PromiseCard>, 'isList'>[];
 
 	type SortByOptions = 'วันที่เคลื่อนไหวล่าสุด' | 'ตัวอักษร' | 'สถานะ';
 	let sortBy: SortByOptions = 'วันที่เคลื่อนไหวล่าสุด';
@@ -87,8 +87,17 @@
 		</div>
 	{/if}
 	<div class="{isList ? 'flex flex-col gap-[2px]' : 'grid gap-6 md:grid-cols-3'} mx-auto w-fit">
-		{#each sortedData as promiseSummary, index (index)}
-			<PromiseCard {promiseSummary} {isList} />
+		{#each sortedData as { id, status, latestProgressDate, party, statements, keywords, categories }, index (index)}
+			<PromiseCard
+				{id}
+				{status}
+				{latestProgressDate}
+				{party}
+				{statements}
+				{keywords}
+				{categories}
+				{isList}
+			/>
 		{/each}
 	</div>
 </div>

--- a/src/components/PromiseList/PromiseList.svelte
+++ b/src/components/PromiseList/PromiseList.svelte
@@ -87,17 +87,8 @@
 		</div>
 	{/if}
 	<div class="{isList ? 'flex flex-col gap-[2px]' : 'grid gap-6 md:grid-cols-3'} mx-auto w-fit">
-		{#each sortedData as { id, status, latestProgressDate, party, statements, keywords, categories }, index (index)}
-			<PromiseCard
-				{id}
-				{status}
-				{latestProgressDate}
-				{party}
-				{statements}
-				{keywords}
-				{categories}
-				{isList}
-			/>
+		{#each sortedData as promiseSummary, index (index)}
+			<PromiseCard {...promiseSummary} {isList} />
 		{/each}
 	</div>
 </div>


### PR DESCRIPTION
# Related GitHub issues

Close #166

## What have been done

- Remove the models import from `PromiseList` and `PromiseCard`.
- Define the `PromiseSummary` type in `PromiseCard`.
- Use svelte's `ComponentProps` to extract the summary type in `PromiseList`
- FYI, I didn't include color in the party field because I found no usage for it.

## Screenshot (if any)

## Help needed (if any)
This is my first PR here. Please let me know if anything needs improvement or changes.

