### PR TITLE
Decouple model from BillCard

### DIFF
--- a/src/components/BillCard/BillCard.story.svelte
+++ b/src/components/BillCard/BillCard.story.svelte
@@ -18,13 +18,20 @@
 	}}
 >
 	<Hst.Variant title="BillCard.Landscape">
-		<BillCard bill={inProgressBill} {currentState} {daySinceProposed} {isFullWidth} />
+		<BillCard
+			bill={inProgressBill}
+			{...inProgressBill}
+			{currentState}
+			{daySinceProposed}
+			{isFullWidth}
+		/>
 	</Hst.Variant>
 
 	<Hst.Variant title="BillCard.Portrait">
 		<BillCard
 			orientation="portrait"
 			bill={inProgressBill}
+			{...inProgressBill}
 			{currentState}
 			{daySinceProposed}
 			{isFullWidth}

--- a/src/components/BillCard/BillCard.story.svelte
+++ b/src/components/BillCard/BillCard.story.svelte
@@ -18,19 +18,12 @@
 	}}
 >
 	<Hst.Variant title="BillCard.Landscape">
-		<BillCard
-			bill={inProgressBill}
-			{...inProgressBill}
-			{currentState}
-			{daySinceProposed}
-			{isFullWidth}
-		/>
+		<BillCard {...inProgressBill} {currentState} {daySinceProposed} {isFullWidth} />
 	</Hst.Variant>
 
 	<Hst.Variant title="BillCard.Portrait">
 		<BillCard
 			orientation="portrait"
-			bill={inProgressBill}
 			{...inProgressBill}
 			{currentState}
 			{daySinceProposed}

--- a/src/components/BillCard/BillCard.svelte
+++ b/src/components/BillCard/BillCard.svelte
@@ -38,7 +38,7 @@
 		<a href="/bills/{id}" class="block after:absolute after:inset-0 after:content-['']">
 			<h3 class="fluid-heading-03 text-text-01">{nickname}</h3>
 		</a>
-		<p class="text-sm text-text-02"><span class="mr-1 font-bold">ชื่อทางการ</span>{bill.title}</p>
+		<p class="text-sm text-text-02"><span class="mr-1 font-bold">ชื่อทางการ</span>{title}</p>
 		<p class="font-semibold">เสนอโดย</p>
 		<Proposer {bill} />
 	</div>

--- a/src/components/BillCard/BillCard.svelte
+++ b/src/components/BillCard/BillCard.svelte
@@ -5,9 +5,6 @@
 	import { twMerge } from 'tailwind-merge';
 	import Proposer from '$components/Proposer/Proposer.svelte';
 
-	// TODO: Remove bill from props when Proposer is refactored.
-	export let bill: Bill;
-
 	export let id: string;
 	export let nickname: string;
 	export let title: string;
@@ -22,6 +19,14 @@
 	export { className as class };
 
 	$: isLandscape = orientation === 'landscape';
+
+	$: bill = {
+		id,
+		nickname,
+		title,
+		proposedOn,
+		status
+	} as Bill;
 </script>
 
 <div

--- a/src/components/BillCard/BillCard.svelte
+++ b/src/components/BillCard/BillCard.svelte
@@ -1,11 +1,19 @@
 <script lang="ts">
 	import { ArrowRight } from 'carbon-icons-svelte';
 	import BillStatusTag from '$components/BillStatusTag/BillStatusTag.svelte';
-	import { type Bill } from '$models/bill';
+	import { BillStatus, type Bill } from '$models/bill';
 	import { twMerge } from 'tailwind-merge';
 	import Proposer from '$components/Proposer/Proposer.svelte';
 
+	// TODO: Remove bill from props when Proposer is refactored.
 	export let bill: Bill;
+
+	export let id: string;
+	export let nickname: string;
+	export let title: string;
+	export let proposedOn: Date | undefined;
+	export let status: BillStatus;
+
 	export let orientation: 'landscape' | 'portrait' = 'landscape';
 	export let currentState: string | undefined = undefined;
 	export let daySinceProposed: number | undefined = undefined;
@@ -27,8 +35,8 @@
 	)}
 >
 	<div class={twMerge('space-y-1', isLandscape ? 'w-full md:w-2/3' : 'w-full')}>
-		<a href="/bills/{bill.id}" class="block after:absolute after:inset-0 after:content-['']">
-			<h3 class="fluid-heading-03 text-text-01">{bill.nickname}</h3>
+		<a href="/bills/{id}" class="block after:absolute after:inset-0 after:content-['']">
+			<h3 class="fluid-heading-03 text-text-01">{nickname}</h3>
 		</a>
 		<p class="text-sm text-text-02"><span class="mr-1 font-bold">ชื่อทางการ</span>{bill.title}</p>
 		<p class="font-semibold">เสนอโดย</p>
@@ -41,12 +49,12 @@
 			: 'flex-col gap-y-4'}"
 	>
 		<div class="grow space-y-2">
-			{#if bill.proposedOn}
+			{#if proposedOn}
 				<div>
 					<p class="text-sm font-semibold">วันที่เสนอ</p>
 
 					<p class="text-sm">
-						{bill.proposedOn.toLocaleDateString('th-TH', {
+						{proposedOn.toLocaleDateString('th-TH', {
 							day: 'numeric',
 							month: 'short',
 							year: 'numeric'
@@ -57,7 +65,7 @@
 
 			<div>
 				<p class="text-sm font-semibold">สถานะ</p>
-				<BillStatusTag isLarge status={bill.status} />
+				<BillStatusTag isLarge {status} />
 				{#if currentState}
 					<p class="text-sm font-semibold">{currentState}</p>
 				{/if}

--- a/src/components/Index/BillContent.svelte
+++ b/src/components/Index/BillContent.svelte
@@ -111,7 +111,7 @@
 		{#key selectedCategory}
 			<Carousel>
 				{#each lastestEnactedBills as bill (bill.id)}
-					<BillCard class="keen-slider__slide min-w-72" orientation="portrait" {bill} {...bill} />
+					<BillCard class="keen-slider__slide min-w-72" orientation="portrait" {...bill} />
 				{/each}
 			</Carousel>
 		{/key}

--- a/src/components/Index/BillContent.svelte
+++ b/src/components/Index/BillContent.svelte
@@ -111,7 +111,7 @@
 		{#key selectedCategory}
 			<Carousel>
 				{#each lastestEnactedBills as bill (bill.id)}
-					<BillCard class="keen-slider__slide min-w-72" orientation="portrait" {bill} />
+					<BillCard class="keen-slider__slide min-w-72" orientation="portrait" {bill} {...bill} />
 				{/each}
 			</Carousel>
 		{/key}

--- a/src/components/bills/Progress.svelte
+++ b/src/components/bills/Progress.svelte
@@ -108,6 +108,7 @@
 					<BillCard
 						orientation="portrait"
 						bill={mergedIntoBill}
+						{...mergedIntoBill}
 						isFullWidth={true}
 						currentState={mergedIntoBillLatestEvent ? event.title : ''}
 					/>

--- a/src/components/bills/Progress.svelte
+++ b/src/components/bills/Progress.svelte
@@ -107,7 +107,6 @@
 				<div class="w-full rounded-sm border border-gray-20">
 					<BillCard
 						orientation="portrait"
-						bill={mergedIntoBill}
 						{...mergedIntoBill}
 						isFullWidth={true}
 						currentState={mergedIntoBillLatestEvent ? event.title : ''}

--- a/src/routes/bills/+page.svelte
+++ b/src/routes/bills/+page.svelte
@@ -95,7 +95,7 @@
 		</h2>
 		<Carousel>
 			{#each data.latestEnactedBills as bill (bill.id)}
-				<BillCard class="keen-slider__slide min-w-72" orientation="portrait" {bill} />
+				<BillCard class="keen-slider__slide min-w-72" orientation="portrait" {bill} {...bill} />
 			{/each}
 		</Carousel>
 	</section>

--- a/src/routes/bills/+page.svelte
+++ b/src/routes/bills/+page.svelte
@@ -95,7 +95,7 @@
 		</h2>
 		<Carousel>
 			{#each data.latestEnactedBills as bill (bill.id)}
-				<BillCard class="keen-slider__slide min-w-72" orientation="portrait" {bill} {...bill} />
+				<BillCard class="keen-slider__slide min-w-72" orientation="portrait" {...bill} />
 			{/each}
 		</Carousel>
 	</section>


### PR DESCRIPTION
# Related GitHub issues

Close #162

## What have been done

- Decouple model from `BillCard`
- Note: Currently left `bill` props in `BillCard` due to currently depended on `Proposer` which will be refactored in issue #167, I added `TODO` for that issue though.

## Screenshot (if any)

## Help needed (if any)
