### PR TITLE
Decouple VoteCard from model

### DIFF
--- a/src/components/Index/VotingContent.svelte
+++ b/src/components/Index/VotingContent.svelte
@@ -12,7 +12,7 @@
 	<h3 class="fluid-heading-04 mb-4">{latestVotings.length} ผลการลงมติล่าสุด</h3>
 	<Carousel>
 		{#each latestVotings as voting}
-			<VoteCard class="keen-slider__slide" {voting} />
+			<VoteCard class="keen-slider__slide" {...voting} />
 		{/each}
 	</Carousel>
 </div>

--- a/src/components/Index/VotingContent.svelte
+++ b/src/components/Index/VotingContent.svelte
@@ -11,8 +11,8 @@
 <div>
 	<h3 class="fluid-heading-04 mb-4">{latestVotings.length} ผลการลงมติล่าสุด</h3>
 	<Carousel>
-		{#each latestVotings as { voting, highlightedVoteByGroups } (voting.id)}
-			<VoteCard class="keen-slider__slide" {voting} {highlightedVoteByGroups} />
+		{#each latestVotings as voting}
+			<VoteCard class="keen-slider__slide" {voting} />
 		{/each}
 	</Carousel>
 </div>

--- a/src/components/PromiseDetail/PromiseProgressTimeline.svelte
+++ b/src/components/PromiseDetail/PromiseProgressTimeline.svelte
@@ -104,16 +104,14 @@
 				</div>
 				{#if isProgress && event.votingSummary}
 					<VoteCard
-						voting={{
-							id: event.votingSummary.id,
-							nickname: event.votingSummary.title || '',
-							date: event.votingSummary.date,
-							result: event.votingSummary.result,
-							votesByGroup: highlightedVoteByGroups(
-								event.votingSummary.resultsByAffiliation,
-								event.votingSummary.result
-							)
-						}}
+						id={event.votingSummary.id}
+						nickname={event.votingSummary.title || ''}
+						date={event.votingSummary.date}
+						result={event.votingSummary.result}
+						votesByGroup={highlightedVoteByGroups(
+							event.votingSummary.resultsByAffiliation,
+							event.votingSummary.result
+						)}
 						class="mb-4"
 					/>
 				{/if}

--- a/src/components/PromiseDetail/PromiseProgressTimeline.svelte
+++ b/src/components/PromiseDetail/PromiseProgressTimeline.svelte
@@ -108,12 +108,12 @@
 							id: event.votingSummary.id,
 							nickname: event.votingSummary.title || '',
 							date: event.votingSummary.date,
-							result: event.votingSummary.result
+							result: event.votingSummary.result,
+							votesByGroup: highlightedVoteByGroups(
+								event.votingSummary.resultsByAffiliation,
+								event.votingSummary.result
+							)
 						}}
-						highlightedVoteByGroups={highlightedVoteByGroups(
-							event.votingSummary.resultsByAffiliation,
-							event.votingSummary.result
-						)}
 						class="mb-4"
 					/>
 				{/if}

--- a/src/components/VoteCard/VoteCard.story.svelte
+++ b/src/components/VoteCard/VoteCard.story.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { DefaultVotingResult } from '$models/voting';
 	import type { ComponentProps } from 'svelte';
-	import VoteCard, { type VoteCardVoting, type HighlightedVoteByGroup } from './VoteCard.svelte';
+	import VoteCard, { type HighlightedVoteByGroup } from './VoteCard.svelte';
 	import type { Hst } from '@histoire/plugin-svelte';
 
 	export let Hst: Hst;
@@ -24,7 +24,7 @@
 		}
 	];
 
-	const passedVoting: VoteCardVoting = {
+	const passedVoting: ComponentProps<VoteCard> = {
 		id: '1',
 		date: new Date('2023-08-31T17:00:00.000Z'),
 		nickname: 'ร่าง พ.ร.บ.สุราก้าวหน้า (ส่งไป ครม.)',
@@ -32,7 +32,7 @@
 		votesByGroup: passedHighlightedVoteByGroups
 	};
 
-	const failedVoting: VoteCardVoting = {
+	const failedVoting: ComponentProps<VoteCard> = {
 		id: '2',
 		date: new Date('2023-09-01T17:00:00.000Z'),
 		nickname: 'ร่าง พ.ร.บ.สุราก้าวหน้า (ส่งไป ครม.)',
@@ -57,36 +57,30 @@
 	};
 
 	const dictVoteCardProps: Record<DefaultVotingResult, ComponentProps<VoteCard>> = {
-		[DefaultVotingResult.Passed]: {
-			voting: passedVoting
-		},
-		[DefaultVotingResult.Failed]: {
-			voting: failedVoting
-		}
+		[DefaultVotingResult.Passed]: passedVoting,
+		[DefaultVotingResult.Failed]: failedVoting
 	};
 
 	let result: DefaultVotingResult = DefaultVotingResult.Passed;
 	let candidateName = '';
 
 	$: isCandidateResult = 'candidate' === (result as string);
-	$: ({ voting } = dictVoteCardProps[result] || candidateVoteCardProps);
+	$: voting = dictVoteCardProps[result] || candidateVoteCardProps;
 	$: candidateVoteCardProps = {
-		voting: {
-			id: '3',
-			/**
-			 * @author fResult <Styxmaz@gmail.com>
-			 * FIXME: Actually, it should be new Date('2023-09-02T17:00:00.000Z'), but I can't get Date object from Reactivity (Proxie)
-			 */
-			date: '2023-09-02T17:00:00.000Z' as unknown as Date,
-			nickname: 'เลือกนายกรัฐมนตรีไทย คนที่ 29',
-			result: candidateName || 'Mr. Candidate Krub',
-			votesByGroup: passedHighlightedVoteByGroups
-		}
+		id: '3',
+		/**
+		 * @author fResult <Styxmaz@gmail.com>
+		 * FIXME: Actually, it should be new Date('2023-09-02T17:00:00.000Z'), but I can't get Date object from Reactivity (Proxie)
+		 */
+		date: '2023-09-02T17:00:00.000Z' as unknown as Date,
+		nickname: 'เลือกนายกรัฐมนตรีไทย คนที่ 29',
+		result: candidateName || 'Mr. Candidate Krub',
+		votesByGroup: passedHighlightedVoteByGroups
 	} satisfies ComponentProps<VoteCard>;
 </script>
 
 <Hst.Story title="VoteCard">
-	<VoteCard {voting} />
+	<VoteCard {...voting} />
 
 	<svelte:fragment slot="controls">
 		<p>Card Result:</p>

--- a/src/components/VoteCard/VoteCard.story.svelte
+++ b/src/components/VoteCard/VoteCard.story.svelte
@@ -6,20 +6,6 @@
 
 	export let Hst: Hst;
 
-	const passedVoting: VoteCardVoting = {
-		id: '1',
-		date: new Date('2023-08-31T17:00:00.000Z'),
-		nickname: 'ร่าง พ.ร.บ.สุราก้าวหน้า (ส่งไป ครม.)',
-		result: DefaultVotingResult.Passed
-	};
-
-	const failedVoting: VoteCardVoting = {
-		id: '2',
-		date: new Date('2023-09-01T17:00:00.000Z'),
-		nickname: 'ร่าง พ.ร.บ.สุราก้าวหน้า (ส่งไป ครม.)',
-		result: DefaultVotingResult.Failed
-	};
-
 	const passedHighlightedVoteByGroups: HighlightedVoteByGroup[] = [
 		{
 			name: 'สส.ฝ่ายรัฐบาล',
@@ -38,32 +24,44 @@
 		}
 	];
 
-	const failedHighlightedVoteByGroups: HighlightedVoteByGroup[] = [
-		{
-			name: 'สส.ฝ่ายรัฐบาล',
-			count: 16,
-			total: 315
-		},
-		{
-			name: 'สส.ฝ่ายค้าน',
-			count: 4,
-			total: 185
-		},
-		{
-			name: 'สว.',
-			count: 20,
-			total: 250
-		}
-	];
+	const passedVoting: VoteCardVoting = {
+		id: '1',
+		date: new Date('2023-08-31T17:00:00.000Z'),
+		nickname: 'ร่าง พ.ร.บ.สุราก้าวหน้า (ส่งไป ครม.)',
+		result: DefaultVotingResult.Passed,
+		votesByGroup: passedHighlightedVoteByGroups
+	};
+
+	const failedVoting: VoteCardVoting = {
+		id: '2',
+		date: new Date('2023-09-01T17:00:00.000Z'),
+		nickname: 'ร่าง พ.ร.บ.สุราก้าวหน้า (ส่งไป ครม.)',
+		result: DefaultVotingResult.Failed,
+		votesByGroup: [
+			{
+				name: 'สส.ฝ่ายรัฐบาล',
+				count: 16,
+				total: 315
+			},
+			{
+				name: 'สส.ฝ่ายค้าน',
+				count: 4,
+				total: 185
+			},
+			{
+				name: 'สว.',
+				count: 20,
+				total: 250
+			}
+		]
+	};
 
 	const dictVoteCardProps: Record<DefaultVotingResult, ComponentProps<VoteCard>> = {
 		[DefaultVotingResult.Passed]: {
-			voting: passedVoting,
-			highlightedVoteByGroups: passedHighlightedVoteByGroups
+			voting: passedVoting
 		},
 		[DefaultVotingResult.Failed]: {
-			voting: failedVoting,
-			highlightedVoteByGroups: failedHighlightedVoteByGroups
+			voting: failedVoting
 		}
 	};
 
@@ -71,27 +69,24 @@
 	let candidateName = '';
 
 	$: isCandidateResult = 'candidate' === (result as string);
-	$: ({ voting, highlightedVoteByGroups } = dictVoteCardProps[result] || candidateVoteCardProps);
-
-	$: candidateVoting = {
-		id: '3',
-		/**
-		 * @author fResult <Styxmaz@gmail.com>
-		 * FIXME: Actually, it should be new Date('2023-09-02T17:00:00.000Z'), but I can't get Date object from Reactivity (Proxie)
-		 */
-		date: '2023-09-02T17:00:00.000Z' as unknown as Date,
-		nickname: 'เลือกนายกรัฐมนตรีไทย คนที่ 29',
-		result: candidateName || 'Mr. Candidate Krub'
-	} satisfies VoteCardVoting;
-
+	$: ({ voting } = dictVoteCardProps[result] || candidateVoteCardProps);
 	$: candidateVoteCardProps = {
-		voting: candidateVoting,
-		highlightedVoteByGroups: passedHighlightedVoteByGroups
+		voting: {
+			id: '3',
+			/**
+			 * @author fResult <Styxmaz@gmail.com>
+			 * FIXME: Actually, it should be new Date('2023-09-02T17:00:00.000Z'), but I can't get Date object from Reactivity (Proxie)
+			 */
+			date: '2023-09-02T17:00:00.000Z' as unknown as Date,
+			nickname: 'เลือกนายกรัฐมนตรีไทย คนที่ 29',
+			result: candidateName || 'Mr. Candidate Krub',
+			votesByGroup: passedHighlightedVoteByGroups
+		}
 	} satisfies ComponentProps<VoteCard>;
 </script>
 
 <Hst.Story title="VoteCard">
-	<VoteCard {voting} {highlightedVoteByGroups} />
+	<VoteCard {voting} />
 
 	<svelte:fragment slot="controls">
 		<p>Card Result:</p>
@@ -110,6 +105,6 @@
 
 		<p>Example Props:</p>
 		<Hst.Json title="Example `voting` Prop" bind:value={voting} />
-		<Hst.Json title="Example `highlightedVoteByGroups` Prop" bind:value={highlightedVoteByGroups} />
+		<Hst.Json title="Example `highlightedVoteByGroups` Prop" bind:value={voting.votesByGroup} />
 	</svelte:fragment>
 </Hst.Story>

--- a/src/components/VoteCard/VoteCard.svelte
+++ b/src/components/VoteCard/VoteCard.svelte
@@ -4,14 +4,6 @@
 		count: number;
 		total: number;
 	}
-
-	export type VoteCardVoting = {
-		date: Date;
-		nickname: string;
-		id: string;
-		result: string;
-		votesByGroup: HighlightedVoteByGroup[];
-	};
 </script>
 
 <script lang="ts">
@@ -53,7 +45,11 @@
 		tagFontColor: 'text-white'
 	};
 
-	export let voting: VoteCardVoting;
+	export let date: Date;
+	export let nickname: string;
+	export let id: string;
+	export let result: string;
+	export let votesByGroup: HighlightedVoteByGroup[];
 	export let isFullWidth = false;
 
 	let className = '';
@@ -63,16 +59,16 @@
 		totalCount: number;
 		totalAmount: number;
 	}
-	$: ({ totalCount, totalAmount } = voting.votesByGroup.reduce<HighlightedVoteSummary>(
+	$: ({ totalCount, totalAmount } = votesByGroup.reduce<HighlightedVoteSummary>(
 		reduceHighlightedVoteSummary,
 		{
 			totalCount: 0,
 			totalAmount: 0
 		}
 	));
-	$: theme = CARD_THEMES[voting.result as DefaultVotingResult] || CANDIDATE_CARD_THEME;
+	$: theme = CARD_THEMES[result as DefaultVotingResult] || CANDIDATE_CARD_THEME;
 	$: isCandidate = ![DefaultVotingResult.Failed, DefaultVotingResult.Passed].includes(
-		voting.result as DefaultVotingResult
+		result as DefaultVotingResult
 	);
 
 	function reduceHighlightedVoteSummary(
@@ -87,7 +83,7 @@
 </script>
 
 <a
-	href="/votings/{voting.id}"
+	href="/votings/{id}"
 	class={twMerge(
 		'vote-card h-64.5 relative flex w-72 flex-col gap-y-2 whitespace-break-spaces rounded-sm p-4',
 		theme.bg,
@@ -97,18 +93,18 @@
 	)}
 >
 	<p class="body-compact-01 text-text-02">
-		{dayjs(voting.date).format('D MMM BB')}
+		{dayjs(date).format('D MMM BB')}
 	</p>
-	<h3 class="fluid-heading-03 text-text-01">{voting.nickname}</h3>
+	<h3 class="fluid-heading-03 text-text-01">{nickname}</h3>
 	<section class="vote-card__result flex w-56 flex-col gap-y-2">
-		<Tag class={`label-01 ${theme.tagFontColor} ${theme.tagBg} m-0 w-fit`}>{voting.result}</Tag>
+		<Tag class={`label-01 ${theme.tagFontColor} ${theme.tagBg} m-0 w-fit`}>{result}</Tag>
 		<div class="flex flex-col gap-x-1">
 			{#if totalAmount > 0}
 				<div class="flex items-center justify-between">
 					<p class="heading-01 text-text-01">
 						{isCandidate
 							? 'ได้รับคะแนนเสียง'
-							: voting.result === DefaultVotingResult.Passed
+							: result === DefaultVotingResult.Passed
 								? DefaultVoteOption.Agreed
 								: DefaultVoteOption.Disagreed}
 					</p>
@@ -119,7 +115,7 @@
 				</div>
 			{/if}
 			<ul class="vote-card__result--list">
-				{#each voting.votesByGroup as voteByGroup (voteByGroup.name)}
+				{#each votesByGroup as voteByGroup (voteByGroup.name)}
 					<li class="vote-card__result--item flex flex-row justify-between align-middle">
 						<p class="body-01 text-text-01">{voteByGroup.name}</p>
 						<p class="body-01">

--- a/src/components/VoteCard/VoteCard.svelte
+++ b/src/components/VoteCard/VoteCard.svelte
@@ -1,16 +1,22 @@
 <script context="module" lang="ts">
-	export type VoteCardVoting = Pick<Voting, 'id' | 'nickname' | 'date' | 'result'>;
-
 	export interface HighlightedVoteByGroup {
 		name: string;
 		count: number;
 		total: number;
 	}
+
+	export type VoteCardVoting = {
+		date: Date;
+		nickname: string;
+		id: string;
+		result: string;
+		votesByGroup: HighlightedVoteByGroup[];
+	};
 </script>
 
 <script lang="ts">
 	import DirectionStraightRight from 'carbon-icons-svelte/lib/DirectionStraightRight.svelte';
-	import { DefaultVoteOption, DefaultVotingResult, type Voting } from '$models/voting';
+	import { DefaultVoteOption, DefaultVotingResult } from '$models/voting';
 	import { Tag } from 'carbon-components-svelte';
 	import dayjs from 'dayjs';
 	import 'dayjs/locale/th';
@@ -48,7 +54,6 @@
 	};
 
 	export let voting: VoteCardVoting;
-	export let highlightedVoteByGroups: HighlightedVoteByGroup[] = [];
 	export let isFullWidth = false;
 
 	let className = '';
@@ -58,9 +63,12 @@
 		totalCount: number;
 		totalAmount: number;
 	}
-	$: ({ totalCount, totalAmount } = highlightedVoteByGroups.reduce<HighlightedVoteSummary>(
+	$: ({ totalCount, totalAmount } = voting.votesByGroup.reduce<HighlightedVoteSummary>(
 		reduceHighlightedVoteSummary,
-		{ totalCount: 0, totalAmount: 0 }
+		{
+			totalCount: 0,
+			totalAmount: 0
+		}
 	));
 	$: theme = CARD_THEMES[voting.result as DefaultVotingResult] || CANDIDATE_CARD_THEME;
 	$: isCandidate = ![DefaultVotingResult.Failed, DefaultVotingResult.Passed].includes(
@@ -111,7 +119,7 @@
 				</div>
 			{/if}
 			<ul class="vote-card__result--list">
-				{#each highlightedVoteByGroups as voteByGroup (voteByGroup.name)}
+				{#each voting.votesByGroup as voteByGroup (voteByGroup.name)}
 					<li class="vote-card__result--item flex flex-row justify-between align-middle">
 						<p class="body-01 text-text-01">{voteByGroup.name}</p>
 						<p class="body-01">

--- a/src/components/bills/Progress.svelte
+++ b/src/components/bills/Progress.svelte
@@ -26,7 +26,7 @@
 	import { Button } from 'carbon-components-svelte';
 	import BillCard from '$components/BillCard/BillCard.svelte';
 	import type { Voting } from '$models/voting';
-	import { toVoteCardVoting } from '$lib/datasheets/voting';
+	import { toVoteCardVoting } from '$lib/model-component-adapters/votecardvoting';
 	export let event: BillEvent;
 	export let tooltipText: string;
 	export let relatedVotingResults: RelatedVotingResults | undefined;
@@ -90,7 +90,7 @@
 		{#if voting}
 			<div class="flex flex-1 flex-col">
 				<p class="text-text-02">ผลการลงมติ</p>
-				<VoteCard isFullWidth={true} {voting} />
+				<VoteCard isFullWidth {...voting} />
 			</div>
 		{:else if event.enforcementDocumentUrl}
 			<div class="flex-1 pt-5">

--- a/src/components/bills/Progress.svelte
+++ b/src/components/bills/Progress.svelte
@@ -26,7 +26,7 @@
 	import { Button } from 'carbon-components-svelte';
 	import BillCard from '$components/BillCard/BillCard.svelte';
 	import type { Voting } from '$models/voting';
-
+	import { toVoteCardVoting } from '$lib/datasheets/voting';
 	export let event: BillEvent;
 	export let tooltipText: string;
 	export let relatedVotingResults: RelatedVotingResults | undefined;
@@ -39,12 +39,16 @@
 		day: 'numeric'
 	};
 
-	$: voting = event.votedInVotingId
-		? relatedVotingResults?.[event.votedInVotingId]?.voting
-		: undefined;
+	$: voting = (() => {
+		let voting;
+		if (event.votedInVotingId) {
+			voting = relatedVotingResults?.[event.votedInVotingId]?.voting;
+		}
+		return voting ? toVoteCardVoting(voting, highlightedVoteByGroups) : undefined;
+	})();
 
 	$: highlightedVoteByGroups = (() => {
-		if (!event.votedInVotingId) return undefined;
+		if (!event.votedInVotingId) return [];
 
 		const resultSummary = relatedVotingResults?.[event.votedInVotingId]?.resultSummary;
 
@@ -64,7 +68,7 @@
 			];
 		}
 
-		return undefined;
+		return [];
 	})();
 </script>
 
@@ -83,10 +87,10 @@
 				<p>{event.description}</p>
 			</div>
 		</div>
-		{#if voting && highlightedVoteByGroups}
+		{#if voting}
 			<div class="flex flex-1 flex-col">
 				<p class="text-text-02">ผลการลงมติ</p>
-				<VoteCard isFullWidth={true} {voting} {highlightedVoteByGroups} />
+				<VoteCard isFullWidth={true} {voting} />
 			</div>
 		{:else if event.enforcementDocumentUrl}
 			<div class="flex-1 pt-5">

--- a/src/lib/datasheets/voting.ts
+++ b/src/lib/datasheets/voting.ts
@@ -1,4 +1,4 @@
-import { type HighlightedVoteByGroup, VoteCard } from '$components/VoteCard/VoteCard.svelte';
+import VoteCard, { type HighlightedVoteByGroup } from '$components/VoteCard/VoteCard.svelte';
 import { logger } from '$lib/logger';
 import { AssemblyName, type Assembly } from '$models/assembly';
 import type { Party } from '$models/party';

--- a/src/lib/datasheets/voting.ts
+++ b/src/lib/datasheets/voting.ts
@@ -53,19 +53,6 @@ export function getHighlightedVoteByGroups(
 		.filter(({ count }) => count > 0);
 }
 
-export function toVoteCardVoting(
-	voting: Voting,
-	highlightedVoteByGroups: HighlightedVoteByGroup[]
-): VoteCardVoting {
-	return {
-		id: voting.id,
-		date: voting.date,
-		nickname: voting.nickname,
-		result: voting.result,
-		votesByGroup: highlightedVoteByGroups
-	};
-}
-
 export function groupVoteByAffiliations(
 	voting: Voting,
 	votes: Vote[],

--- a/src/lib/datasheets/voting.ts
+++ b/src/lib/datasheets/voting.ts
@@ -1,7 +1,4 @@
-import {
-	type HighlightedVoteByGroup,
-	type VoteCardVoting
-} from '$components/VoteCard/VoteCard.svelte';
+import { type HighlightedVoteByGroup, VoteCard } from '$components/VoteCard/VoteCard.svelte';
 import { logger } from '$lib/logger';
 import { AssemblyName, type Assembly } from '$models/assembly';
 import type { Party } from '$models/party';

--- a/src/lib/datasheets/voting.ts
+++ b/src/lib/datasheets/voting.ts
@@ -1,4 +1,7 @@
-import type { HighlightedVoteByGroup } from '$components/VoteCard/VoteCard.svelte';
+import {
+	type HighlightedVoteByGroup,
+	type VoteCardVoting
+} from '$components/VoteCard/VoteCard.svelte';
 import { logger } from '$lib/logger';
 import { AssemblyName, type Assembly } from '$models/assembly';
 import type { Party } from '$models/party';
@@ -48,6 +51,19 @@ export function getHighlightedVoteByGroups(
 			total: Object.values(resultSummary).reduce((total, count) => total + count, 0)
 		}))
 		.filter(({ count }) => count > 0);
+}
+
+export function toVoteCardVoting(
+	voting: Voting,
+	highlightedVoteByGroups: HighlightedVoteByGroup[]
+): VoteCardVoting {
+	return {
+		id: voting.id,
+		date: voting.date,
+		nickname: voting.nickname,
+		result: voting.result,
+		votesByGroup: highlightedVoteByGroups
+	};
 }
 
 export function groupVoteByAffiliations(

--- a/src/lib/datasheets/voting.ts
+++ b/src/lib/datasheets/voting.ts
@@ -1,4 +1,4 @@
-import VoteCard, { type HighlightedVoteByGroup } from '$components/VoteCard/VoteCard.svelte';
+import type { HighlightedVoteByGroup } from '$components/VoteCard/VoteCard.svelte';
 import { logger } from '$lib/logger';
 import { AssemblyName, type Assembly } from '$models/assembly';
 import type { Party } from '$models/party';

--- a/src/lib/model-component-adapters/votecardvoting.ts
+++ b/src/lib/model-component-adapters/votecardvoting.ts
@@ -1,4 +1,4 @@
-import { type HighlightedVoteByGroup, VoteCard } from '$components/VoteCard/VoteCard.svelte';
+import VoteCard, { type HighlightedVoteByGroup } from '$components/VoteCard/VoteCard.svelte';
 import { type Voting } from '$models/voting';
 import type { ComponentProps } from 'svelte';
 

--- a/src/lib/model-component-adapters/votecardvoting.ts
+++ b/src/lib/model-component-adapters/votecardvoting.ts
@@ -1,13 +1,11 @@
-import {
-	type HighlightedVoteByGroup,
-	type VoteCardVoting
-} from '$components/VoteCard/VoteCard.svelte';
+import { type HighlightedVoteByGroup, type VoteCard } from '$components/VoteCard/VoteCard.svelte';
 import { type Voting } from '$models/voting';
+import type { ComponentProps } from 'svelte';
 
 export function toVoteCardVoting(
 	voting: Voting,
 	highlightedVoteByGroups: HighlightedVoteByGroup[]
-): VoteCardVoting {
+): ComponentProps<VoteCard> {
 	return {
 		id: voting.id,
 		date: voting.date,

--- a/src/lib/model-component-adapters/votecardvoting.ts
+++ b/src/lib/model-component-adapters/votecardvoting.ts
@@ -1,0 +1,18 @@
+import {
+	type HighlightedVoteByGroup,
+	type VoteCardVoting
+} from '$components/VoteCard/VoteCard.svelte';
+import { type Voting } from '$models/voting';
+
+export function toVoteCardVoting(
+	voting: Voting,
+	highlightedVoteByGroups: HighlightedVoteByGroup[]
+): VoteCardVoting {
+	return {
+		id: voting.id,
+		date: voting.date,
+		nickname: voting.nickname,
+		result: voting.result,
+		votesByGroup: highlightedVoteByGroups
+	};
+}

--- a/src/lib/model-component-adapters/votecardvoting.ts
+++ b/src/lib/model-component-adapters/votecardvoting.ts
@@ -1,4 +1,4 @@
-import { type HighlightedVoteByGroup, type VoteCard } from '$components/VoteCard/VoteCard.svelte';
+import { type HighlightedVoteByGroup, VoteCard } from '$components/VoteCard/VoteCard.svelte';
 import { type Voting } from '$models/voting';
 import type { ComponentProps } from 'svelte';
 

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -16,7 +16,8 @@ import {
 	fetchVotings
 } from '$lib/datasheets';
 import { safeFind } from '$lib/datasheets/processor.js';
-import { getHighlightedVoteByGroups, toVoteCardVoting } from '$lib/datasheets/voting.js';
+import { getHighlightedVoteByGroups } from '$lib/datasheets/voting.js';
+import { toVoteCardVoting } from '$lib/model-component-adapters/votecardvoting';
 import { BillStatus } from '$models/bill';
 import { PromiseStatus } from '$models/promise';
 import type { PromisesByStatus } from './promises/+page.server';

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -16,7 +16,7 @@ import {
 	fetchVotings
 } from '$lib/datasheets';
 import { safeFind } from '$lib/datasheets/processor.js';
-import { getHighlightedVoteByGroups } from '$lib/datasheets/voting.js';
+import { getHighlightedVoteByGroups, toVoteCardVoting } from '$lib/datasheets/voting.js';
 import { BillStatus } from '$models/bill';
 import { PromiseStatus } from '$models/promise';
 import type { PromisesByStatus } from './promises/+page.server';
@@ -83,10 +83,9 @@ export async function load() {
 	const latestVotings: ComponentProps<VoteCard>[] = [...(await fetchVotings())]
 		.sort((a, z) => z.date.getTime() - a.date.getTime())
 		.slice(0, MAX_LATEST_VOTE)
-		.map((voting) => ({
-			voting,
-			highlightedVoteByGroups: getHighlightedVoteByGroups(voting, votes, politicians, assembles)
-		}));
+		.map((voting) =>
+			toVoteCardVoting(voting, getHighlightedVoteByGroups(voting, votes, politicians, assembles))
+		);
 
 	const billByCategoryAndStatus: BillByCategoryAndStatus = rollup(
 		bills.flatMap(({ categories, ...rest }) =>

--- a/src/routes/assemblies/[id]/+page.server.ts
+++ b/src/routes/assemblies/[id]/+page.server.ts
@@ -11,7 +11,8 @@ import {
 } from '$lib/datasheets';
 import { getAssemblyMembers } from '$lib/datasheets/assembly-member';
 import type { AssemblyMember } from '$lib/datasheets/assembly-member';
-import { getHighlightedVoteByGroups, toVoteCardVoting } from '$lib/datasheets/voting';
+import { getHighlightedVoteByGroups } from '$lib/datasheets/voting';
+import { toVoteCardVoting } from '$lib/model-component-adapters/votecardvoting';
 import { createSeo } from '$lib/seo';
 import { AssemblyName, GroupByOption } from '$models/assembly';
 import type { Bill } from '$models/bill';

--- a/src/routes/assemblies/[id]/+page.server.ts
+++ b/src/routes/assemblies/[id]/+page.server.ts
@@ -11,7 +11,7 @@ import {
 } from '$lib/datasheets';
 import { getAssemblyMembers } from '$lib/datasheets/assembly-member';
 import type { AssemblyMember } from '$lib/datasheets/assembly-member';
-import { getHighlightedVoteByGroups } from '$lib/datasheets/voting';
+import { getHighlightedVoteByGroups, toVoteCardVoting } from '$lib/datasheets/voting';
 import { createSeo } from '$lib/seo';
 import { AssemblyName, GroupByOption } from '$models/assembly';
 import type { Bill } from '$models/bill';
@@ -162,12 +162,9 @@ export async function load({ params }) {
 				.sort((a, z) => z.date.getTime() - a.date.getTime())
 				.slice(0, MAX_LATEST_VOTE)
 				.map((voting) => ({
-					voting,
-					highlightedVoteByGroups: getHighlightedVoteByGroups(
+					voting: toVoteCardVoting(
 						voting,
-						votes,
-						politicians,
-						assemblies
+						getHighlightedVoteByGroups(voting, votes, politicians, assemblies)
 					)
 				}));
 

--- a/src/routes/assemblies/[id]/+page.server.ts
+++ b/src/routes/assemblies/[id]/+page.server.ts
@@ -162,12 +162,12 @@ export async function load({ params }) {
 				)
 				.sort((a, z) => z.date.getTime() - a.date.getTime())
 				.slice(0, MAX_LATEST_VOTE)
-				.map((voting) => ({
-					voting: toVoteCardVoting(
+				.map((voting) =>
+					toVoteCardVoting(
 						voting,
 						getHighlightedVoteByGroups(voting, votes, politicians, assemblies)
 					)
-				}));
+				);
 
 	const latestBills: BillSummary[] | null = isCabinet
 		? (await fetchBills())


### PR DESCRIPTION
# Related GitHub issues

Close #168

## What have been done

- Updated the VoteCardVoting schema to combine the previously picked keys (from Voting) + HighlightedVoteByGroup, into a new type owned by the VoteCard component. The VoteCard component now takes a single VoteCardVoting prop.
- Removed the Voting type import from `/models`
- Added a `toVoteCardVoting: Voting x HighlightedVoteByGroup[] -> VoteCardVoting` convenience function for parent components
