### PR TITLE
refactor: decouple LawStatusCard from model

### DIFF
--- a/src/components/Index/BillContent.svelte
+++ b/src/components/Index/BillContent.svelte
@@ -44,8 +44,11 @@
 	{@const billsByStatus = [...billsBySelectedCategory.billsByStatus.entries()]
 		.map(([status, bill]) => ({
 			status,
-			...bill,
-			samples: bill.samples.slice(0, MAX_BILL_BY_STATUS)
+			count: bill.count,
+			samples: bill.samples.slice(0, MAX_BILL_BY_STATUS).map((s) => ({
+				id: s.id,
+				nickname: s.nickname
+			}))
 		}))
 		.sort((a, z) => billStatusList.indexOf(a.status) - billStatusList.indexOf(z.status))}
 	{@const lastestEnactedBills =

--- a/src/components/LawStatusCard/LawStatusCard.svelte
+++ b/src/components/LawStatusCard/LawStatusCard.svelte
@@ -5,11 +5,31 @@
 	import { BillProposerType, BillStatus } from '$models/bill';
 	import ArrowRight from 'carbon-icons-svelte/lib/ArrowRight.svelte';
 	import DocumentUnknown from 'carbon-icons-svelte/lib/DocumentUnknown.svelte';
-	import type {
-		BillsByCategory,
-		BillsByProposerType,
-		BillsByStatus
-	} from '../../routes/bills/+page.server';
+
+	interface BillSample {
+		id: string;
+		nickname: string;
+	}
+	interface BillsByStatus {
+		status: BillStatus;
+		samples: BillSample[];
+		count: number;
+	}
+
+	interface BillsByCategory {
+		category: string;
+		samples: BillSample[];
+		count: number;
+	}
+
+	interface BillsByProposerType {
+		proposerType: BillProposerType;
+		samples: BillSample[];
+		count: number;
+		countByStatus: {
+			[status in BillStatus]: number;
+		};
+	}
 
 	export let totalCount: number;
 	export let bill: BillsByStatus | BillsByCategory | BillsByProposerType;

--- a/src/components/LawStatusCard/LawStatusCard.svelte
+++ b/src/components/LawStatusCard/LawStatusCard.svelte
@@ -1,28 +1,21 @@
-<script lang="ts">
-	import GeneralIcon from '$components/icons/GeneralIcon.svelte';
-	import PeopleIcon from '$components/icons/PeopleIcon.svelte';
-	import PoliticianIcon from '$components/icons/PoliticianIcon.svelte';
-	import { BillProposerType, BillStatus } from '$models/bill';
-	import ArrowRight from 'carbon-icons-svelte/lib/ArrowRight.svelte';
-	import DocumentUnknown from 'carbon-icons-svelte/lib/DocumentUnknown.svelte';
-
-	interface BillSample {
+<script context="module" lang="ts">
+	export interface BillSample {
 		id: string;
 		nickname: string;
 	}
-	interface BillsByStatus {
+	export interface BillsByStatus {
 		status: BillStatus;
 		samples: BillSample[];
 		count: number;
 	}
 
-	interface BillsByCategory {
+	export interface BillsByCategory {
 		category: string;
 		samples: BillSample[];
 		count: number;
 	}
 
-	interface BillsByProposerType {
+	export interface BillsByProposerType {
 		proposerType: BillProposerType;
 		samples: BillSample[];
 		count: number;
@@ -30,6 +23,15 @@
 			[status in BillStatus]: number;
 		};
 	}
+</script>
+
+<script lang="ts">
+	import GeneralIcon from '$components/icons/GeneralIcon.svelte';
+	import PeopleIcon from '$components/icons/PeopleIcon.svelte';
+	import PoliticianIcon from '$components/icons/PoliticianIcon.svelte';
+	import { BillProposerType, BillStatus } from '$models/bill';
+	import ArrowRight from 'carbon-icons-svelte/lib/ArrowRight.svelte';
+	import DocumentUnknown from 'carbon-icons-svelte/lib/DocumentUnknown.svelte';
 
 	export let totalCount: number;
 	export let bill: BillsByStatus | BillsByCategory | BillsByProposerType;

--- a/src/routes/bills/+page.server.ts
+++ b/src/routes/bills/+page.server.ts
@@ -1,3 +1,8 @@
+import type {
+	BillsByCategory,
+	BillsByProposerType,
+	BillsByStatus
+} from '$components/LawStatusCard/LawStatusCard.svelte';
 import { fetchBills } from '$lib/datasheets';
 import { createSeo } from '$lib/seo';
 import { BillProposerType, BillStatus, type Bill } from '$models/bill';
@@ -5,29 +10,6 @@ import { rollup } from 'd3';
 
 const BILL_SAMPLE_LIMIT = 3;
 const LATEST_ENACTED_BILL_LIMIT = 10;
-
-type BillSample = Pick<Bill, 'id' | 'nickname'>;
-
-export interface BillsByStatus {
-	status: BillStatus;
-	samples: BillSample[];
-	count: number;
-}
-
-export interface BillsByCategory {
-	category: string;
-	samples: BillSample[];
-	count: number;
-}
-
-export interface BillsByProposerType {
-	proposerType: BillProposerType;
-	samples: BillSample[];
-	count: number;
-	countByStatus: {
-		[status in BillStatus]: number;
-	};
-}
 
 export async function load() {
 	const bills = (await fetchBills()).sort(


### PR DESCRIPTION
# Related GitHub issues

Close #164 

## What have been done

- Decouple LawStatusCard from model
- Update BillContent component to use LawStatusCard
## Screenshot
![image](https://github.com/user-attachments/assets/feb30995-7347-4c65-ba9b-406d837fc152)

![image](https://github.com/user-attachments/assets/828be75b-dbd1-4c46-b50e-fd0021133b14)


