### PR TITLE
Fix `ไม่สังกัดพรรค` doesn't display on Assemblies page sidebar

### DIFF
--- a/src/routes/assemblies/[id]/members/[groupby]/+page.svelte
+++ b/src/routes/assemblies/[id]/members/[groupby]/+page.svelte
@@ -64,7 +64,7 @@
 				}) as PoliticianSummaryGroupBy);
 
 	const getSubgroupHeadingId = (group: { name: string }, name?: string) =>
-		(name ? `${group.name}-${name}` : group.name).replaceAll(' ', '-');
+		`${group.name}-${name || NON_PARTISAN}`.replaceAll(' ', '-');
 
 	let memberListSectionRef: HTMLElement;
 


### PR DESCRIPTION
# Related GitHub issues

Close #203

## What have been done

- Display `ไม่สังกัดพรรค` instead empty string on Assemble page's side bar and the page heading level 3

## Screenshot (if any)

**Before:**
<img width="1191" height="1602" alt="image" src="https://github.com/user-attachments/assets/14807a91-4c05-42e3-b9b6-9404cafdc81b" />

**After:**
<img width="1186" height="1231" alt="image" src="https://github.com/user-attachments/assets/db9f6056-0479-4dc0-a471-f8c2a59af244" />

## Help needed (if any)

Please let me know if we need to display Element ID as `<side>-ไม่สังกัดพรรค`, for e.g., `ฝ่ายรัฐบาล-ไม่สังกัดพรรค`
<img width="575" height="402" alt="image" src="https://github.com/user-attachments/assets/418bc35c-e926-4740-90fd-d2fb49cca46d" />

## Did you use AI in your PR? If so, how did you use AI, and what did you do to ensure the quality?
