### PR TITLE
feat: ระบุพรรคปัจจุบันที่สังกัดเป็น bullet สุดท้ายของ 'ตำแหน่งปัจจุบัน'

### DIFF
--- a/src/routes/politicians/[id]/+page.svelte
+++ b/src/routes/politicians/[id]/+page.svelte
@@ -17,8 +17,6 @@
 	import DataPeriodRemark from '$components/DataPeriodRemark/DataPeriodRemark.svelte';
 	import { groups } from 'd3';
 
-	type PartyRole = 'หัวหน้าพรรคการเมือง' | 'สมาชิกพรรคการเมือง';
-
 	export let data;
 
 	$: ({ politician, agreedVoting, disagreedVoting, votingAbsentStats } = data);
@@ -27,7 +25,7 @@
 		(m) => m.posts[0].organizations[0].classification === 'POLITICAL_PARTY'
 	);
 	$: currentPartyMembership = partyMemberships.find(isCurrent);
-	$: currentPartyRole = currentPartyMembership?.posts[0].role as PartyRole;
+	$: currentPartyRole = currentPartyMembership?.posts[0].role;
 	$: currentParty = currentPartyMembership?.posts[0].organizations[0];
 	$: membershipInEachParties = groups(partyMemberships, (m) => m.posts[0].organizations[0].name);
 	$: assemblyMemberships = politician.memberships.filter(


### PR DESCRIPTION
# Related GitHub issues

Close #197

## What have been done

- Added display of the politician’s current party membership and role (e.g. "หัวหน้าพรรค", "สมาชิกพรรค") in the current positions list on the politician detail page.
- Introduced a `PartyRole` type to explicitly define possible political party roles for type safety
- Extracted current party membership and role from the politician’s memberships data
- Added a `roleAliases` mapping to display shortened role labels (e.g. "หัวหน้า", "สมาชิก") in the UI
- Created `isCurrent` function to check if a membership has no end date and replace it to `m.end_date === null`
- Rendered the current party role and party name as a new list item in the "Current Positions" section, ensuring it appears as the last bullet point

## Screenshot (if any)

- สมาชิกพรรค - http://localhost:5173/politicians/891ea463-c463-4f76-840d-e7d24a97d70c    
    <img width="611" height="345" alt="image" src="https://github.com/user-attachments/assets/626b4cd4-9dc7-4e09-971d-cbba775d8fb3" />

- หัวหน้าพรรค http://localhost:5173/politicians/d5409bcf-f304-423e-9079-a593b9ef5dbd
    <img width="774" height="362" alt="image" src="https://github.com/user-attachments/assets/3ba575d8-1197-48c2-80bb-3e6e7577be4a" />

- หัวหน้าพรรค - http://localhost:5173/politicians/4cc8dfaf-e5ce-41f4-94d3-53bf858308b4
    <img width="642" height="380" alt="image" src="https://github.com/user-attachments/assets/62777ba1-2d8f-4894-b256-4599385893ac" />

- ไม่สังกัดพรรค - http://localhost:5173/politicians/f3e40c1c-66e0-4851-a8af-91d0cbf384c2
    <img width="708" height="350" alt="image" src="https://github.com/user-attachments/assets/5ee5dd31-bc79-4aae-bad1-25cf522f3a93" />


## Help needed (if any)

## Did you use AI in your PR? If so, how did you use AI, and what did you do to ensure the quality?
